### PR TITLE
android-creds-mismatch

### DIFF
--- a/s/ci
+++ b/s/ci
@@ -21,5 +21,5 @@ flutter test ${DEFINES_TO_PASS}
 # Android
 flutter build appbundle --release \
   --build-number ${BUILD_NUMBER} \
-  --dart-define=API_URL=$API_URL \
-  --dart-define=API_KEY=$API_KEY
+  --dart-define=DGC_BASE_URL=$API_URL \
+  --dart-define=DGC_API_KEY=$API_KEY


### PR DESCRIPTION
the dart-defines keys for android credentials were wrong so would always be empty