### PR TITLE
Add measurement button

### DIFF
--- a/lib/widgets/centile_chart.dart
+++ b/lib/widgets/centile_chart.dart
@@ -815,7 +815,7 @@ class _CentileChartState extends State<CentileChart> {
                         child: IconButton(
                           icon: Icon(
                             Icons.add_chart,
-                            semanticLabel: "Add measurement"
+                            semanticLabel: "Add measurement",
                           ),
                           tooltip: "Add measurement",
                           onPressed: () {


### PR DESCRIPTION
Fixes #16 

Adds a button on the chart specifically to add a new measurement. Previously you had to know to click "Back" from the chart.

<img width="1248" height="1403" alt="Screenshot 2025-10-20 144431" src="https://github.com/user-attachments/assets/0334420b-412a-4e9d-af07-42049cabe2be" />
