### PR TITLE
Speed up rendering chart

### DIFF
--- a/lib/widgets/centile_chart.dart
+++ b/lib/widgets/centile_chart.dart
@@ -270,19 +270,19 @@ class _CentileChartState extends State<CentileChart> {
           // https://github.com/rcpch/digital-growth-charts-app/issues/28
           // fl_chart is very slow to render dashed lines off screen so clip the lines
           // to the current viewpoint (ensuring we grab the first and last points either side)
-          for(var i = 0; i < allSpots.length; i++) {
-            if(spots.isEmpty && allSpots[i].x >= minX) {
-              if(i > 0) {
+          for (var i = 0; i < allSpots.length; i++) {
+            if (spots.isEmpty && allSpots[i].x >= minX) {
+              if (i > 0) {
                 spots.add(allSpots[i - 1]);
               }
 
               spots.add(allSpots[i]);
-            } else if(allSpots[i].x >= minX && allSpots[i].x <= maxX) {
+            } else if (allSpots[i].x >= minX && allSpots[i].x <= maxX) {
               spots.add(allSpots[i]);
-            } else if(allSpots[i].x > maxX) {
+            } else if (allSpots[i].x > maxX) {
               spots.add(allSpots[i]);
 
-              if(i < allSpots.length - 1) {
+              if (i < allSpots.length - 1) {
                 spots.add(allSpots[i + 1]);
               }
 


### PR DESCRIPTION
Fixes #28 

fl_chart has issues rendering our dashed centile lines when measurements are close together (eg daily). It would be taking 10 or more seconds to render the chart!

If you turn off the dashes it renders fine.

No idea what's causing this but clipping the centile lines to just what's visible in the current viewport seems to fix the problem.

You have to grab the first centile points outside of the viewport too as there's no guarantee that it will contain any centile points as they come back from the server, especially when doing daily plots at a very zoomed in level.