### PR TITLE
Speed up rendering whole life chart

### DIFF
--- a/lib/widgets/centile_chart.dart
+++ b/lib/widgets/centile_chart.dart
@@ -100,7 +100,7 @@ class _CentileChartState extends State<CentileChart> {
         .toList();
   }
 
-  double get minX {
+  double _calculateMinX() {
     final measurementXValues = _getMeasurementXValues();
 
     if (measurementXValues.isEmpty || _isLifeCourseView) {
@@ -128,7 +128,7 @@ class _CentileChartState extends State<CentileChart> {
         padding; // Ensure this allows negative values if dataMinX is negative
   }
 
-  double get maxX {
+  double _calculateMaxX() {
     final measurementXValues = _getMeasurementXValues();
 
     if (measurementXValues.isEmpty || _isLifeCourseView) {
@@ -154,7 +154,7 @@ class _CentileChartState extends State<CentileChart> {
     return dataMaxX + padding;
   }
 
-  double get minY {
+  double _calculateMinY(double minX, double maxX) {
     // For the focused view, consider Y values of measurements and visible centile segments
     final currentMinX =
         minX; // Get the already calculated minX for the current view
@@ -205,7 +205,7 @@ class _CentileChartState extends State<CentileChart> {
     ); // Clamp Y at 0, common for growth charts
   }
 
-  double get maxY {
+  double _calculateMaxY(double minX, double maxX) {
     final currentMinX = minX;
     final currentMaxX = maxX;
     final List<double> relevantYValues = [];
@@ -244,7 +244,7 @@ class _CentileChartState extends State<CentileChart> {
     return dataMaxY + padding;
   }
 
-  List<LineChartBarData> _generateLineBarsData() {
+  List<LineChartBarData> _generateLineBarsData(double minX, double maxX) {
     final List<LineChartBarData> centileLines = [];
 
     // Get the centile data for the specific sex and measurement method from the organized cache
@@ -420,7 +420,7 @@ class _CentileChartState extends State<CentileChart> {
   }
 
   // Determine the appropriate title for the axes based on the measurement method
-  String _getXAxisTitle() {
+  String _getXAxisTitle(double maxX) {
     if (maxX <= 0.0383) {
       return 'Gestational age (weeks)';
     } else if (maxX <= 2) {
@@ -557,7 +557,17 @@ class _CentileChartState extends State<CentileChart> {
         .toList();
     final List<LineChartBarData> connectingMeasurementLines =
         _generateConnectingMeasurementLines();
-    final List<LineChartBarData> centileLines = _generateLineBarsData();
+
+    final minX = _calculateMinX();
+    final maxX = _calculateMaxX();
+
+    final minY = _calculateMinY(minX, maxX);
+    final maxY = _calculateMaxY(minX, maxX);
+
+    final List<LineChartBarData> centileLines = _generateLineBarsData(
+      minX,
+      maxX,
+    );
     // slightly untidy but we are using the LineChart to plot the lines that connect chronological and corrected measurements
     // this means that the connecting lines, if present, need to be bundled with the centile line data
     final List<LineChartBarData> allLineBarsData = [
@@ -585,7 +595,7 @@ class _CentileChartState extends State<CentileChart> {
                             sideTitles:
                                 _getBottomTitles(), // This will need to be adjusted when we scope the x-axis to the data
                             axisNameWidget: Text(
-                              _getXAxisTitle(),
+                              _getXAxisTitle(maxX),
                               style: const TextStyle(
                                 fontWeight: FontWeight.bold,
                                 fontSize: 12,
@@ -655,7 +665,7 @@ class _CentileChartState extends State<CentileChart> {
                             bottomTitles: AxisTitles(
                               sideTitles: _getBottomTitles(),
                               axisNameWidget: Text(
-                                _getXAxisTitle(),
+                                _getXAxisTitle(maxX),
                                 style: const TextStyle(
                                   fontWeight: FontWeight.bold,
                                   fontSize: 12,


### PR DESCRIPTION
Fixes #32 

Profiling showed that we were repeatedly calculating maxX and minX, even though they don't change for a given render.

<img width="1597" height="468" alt="Screenshot 2025-10-23 112139" src="https://github.com/user-attachments/assets/cd6d7803-a433-43cb-80d7-3ee6f3d37fad" />

<img width="1396" height="562" alt="Screenshot 2025-10-23 112114" src="https://github.com/user-attachments/assets/39b20468-7c49-4743-a69e-fb606f84243d" />

Moved them to be calculated once up front and then passed down to the other calculations.

I also changed them from a `get` to a method to make it clearer that they do "heavy" calculation (they're not that heavy but if you do a whole bunch of them in a row it gets slow!)