### PR TITLE
Handle comments in env file

### DIFF
--- a/web/oauth.mjs
+++ b/web/oauth.mjs
@@ -7,7 +7,11 @@ export async function fetchConfig() {
   const env = {};
 
   for (const line of envText.split('\n')) {
-    const [key, value] = line.split('=');
+    const [uncommented] = line.split("#");
+
+    if (!uncommented.trim()) continue;
+
+    const [key, value] = uncommented.split('=');
     env[key.trim()] = value.trim();
   }
 


### PR DESCRIPTION
The web build fetches and reads the env file to handle the OAuth callback. It wasn't correctly handling comments, despite there being one in the README!