### PR TITLE
Add dependabot configuration for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,14 @@
 version: 2
 updates:
 
+    # Check for updates to GitHub Actions every week
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
       interval: "weekly"
+
+    # Check for updates to Dart/Flutter dependencies every day
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
### Overview
Adds Dependabot configuration file that makes Dependabot check for updates.

- Dart/Flutter is checked daily
- GitHub Actions are checked weekly

### Code changes
Only one file: .github/dependabot.yml

### Documentation changes (done or required as a result of this PR)
n/a

### Related Issues
No issues, but I noticed one of your actions is using an outdated `actions/checkout@v4`, so when this is merged to `main` you will get a Dependabot PR to upgrade that action within a week.

### Mentions
@mbarton