### PR TITLE
Revert back to upload-pages-artifact v3

### DIFF
--- a/.github/workflows/deploy-testing.yml
+++ b/.github/workflows/deploy-testing.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Upload artifact for GitHub Pages
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           # Path to the directory containing the static assets to be deployed.
           # Flutter web builds to 'build/web' by default.


### PR DESCRIPTION
Fixes #63 

The .env file is not being included in the artifact uploaded to pages. I suspect the update from v3 to v3 in https://github.com/rcpch/digital-growth-charts-app/pull/57