### PR TITLE
Add multiple types of measurement at once

### DIFF
--- a/lib/definitions/helpers.dart
+++ b/lib/definitions/helpers.dart
@@ -25,3 +25,10 @@ String getMeasurementMethodUnits(String? measurementMethod) {
     return "";
   }
 }
+
+double? calculateBmi(double weight, double height) {
+  if (height <= 0) {
+    return null;
+  }
+  return weight / ((height / 100) * (height / 100));
+}

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -46,7 +46,7 @@ class InputFormState extends State<InputForm> {
     // The null check for currentState is important if the form might not be built yet.
     final formValid =
         _formKey.currentState != null && _formKey.currentState!.validate();
-    // At least one measurement (height, weight, or OFC) must be supplied.
+    // At least one measurement must be supplied.
     final hasMeasurement =
         _heightController.text.isNotEmpty ||
         _weightController.text.isNotEmpty ||

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -1,6 +1,5 @@
 import 'dart:developer' as developer;
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 // RCPCH imports
 import 'package:digital_growth_charts_app/themes/colours.dart';
@@ -10,6 +9,7 @@ import '../definitions/enums.dart';
 import './results.dart';
 import '../widgets/enum_radio_group.dart';
 import '../classes/app_state.dart';
+import '../definitions/helpers.dart';
 
 class InputFormState extends State<InputForm> {
   // A GlobalKey to uniquely identify the Form widget
@@ -23,7 +23,9 @@ class InputFormState extends State<InputForm> {
   final TextEditingController _heightController = TextEditingController();
   final TextEditingController _weightController = TextEditingController();
   final TextEditingController _ofcController = TextEditingController();
+
   final TextEditingController _bmiController = TextEditingController();
+  final TextEditingController _derivedBmiController = TextEditingController();
 
   // Variables to hold the selected dates (stored as DateTime objects for comparisons)
   DateTime? _selectedDob;
@@ -58,6 +60,21 @@ class InputFormState extends State<InputForm> {
     }
   }
 
+  void _updateBmi() {
+    if (_heightController.text.isNotEmpty && _weightController.text.isNotEmpty) {
+      final height = double.tryParse(_heightController.text);
+      final weight = double.tryParse(_weightController.text);
+      if (height != null && weight != null) {
+        final bmi = calculateBmi(weight, height);
+        if (bmi != null) {
+          _derivedBmiController.text = bmi.toStringAsFixed(2);
+        }
+      }
+    } else {
+      _derivedBmiController.clear();
+    }
+  }
+
   @override
   void initState() {
     super.initState();
@@ -80,6 +97,9 @@ class InputFormState extends State<InputForm> {
       _selectedGestationDays = appState.gestationDays!;
       _showGestationFields = true; // Expand gestation section if data exists
     }
+
+    _heightController.addListener(_updateBmi);
+    _weightController.addListener(_updateBmi);
   }
 
   // Function to show the date picker and update the text field and state
@@ -238,6 +258,21 @@ class InputFormState extends State<InputForm> {
             value: _bmiController.text,
           ),
         );
+      } else if(_weightController.text.isNotEmpty && _heightController.text.isNotEmpty) {
+        final bmi = calculateBmi(
+          double.tryParse(_weightController.text) ?? 0,
+          double.tryParse(_heightController.text) ?? 0,
+        );
+
+        if (bmi != null) {
+          tasks.add(
+            appState.addMeasurement(
+              observationDate: clinicDate,
+              method: MeasurementMethod.bmi,
+              value: bmi.toStringAsFixed(2),
+            ),
+          );
+        }
       }
 
       try {
@@ -291,7 +326,9 @@ class InputFormState extends State<InputForm> {
     // Clean up the controllers when the widget is disposed
     _dobController.dispose();
     _observationDateController.dispose();
+    _heightController.removeListener(_updateBmi);
     _heightController.dispose();
+    _weightController.removeListener(_updateBmi);
     _weightController.dispose();
     _ofcController.dispose();
     _bmiController.dispose();
@@ -525,6 +562,7 @@ class InputFormState extends State<InputForm> {
             // Height Input Field
             TextFormField(
               controller: _heightController,
+              enabled: _bmiController.text.isEmpty,
               keyboardType: const TextInputType.numberWithOptions(
                 decimal: true,
               ), // Allow decimal input
@@ -548,6 +586,7 @@ class InputFormState extends State<InputForm> {
             // Weight Input Field
             TextFormField(
               controller: _weightController,
+              enabled: _bmiController.text.isEmpty,
               keyboardType: const TextInputType.numberWithOptions(
                 decimal: true,
               ), // Allow decimal input
@@ -582,6 +621,7 @@ class InputFormState extends State<InputForm> {
                       // Head Circumference (ofc) Input Field
                       TextFormField(
                         controller: _ofcController,
+                        enabled: _bmiController.text.isEmpty,
                         keyboardType: const TextInputType.numberWithOptions(
                           decimal: true,
                         ), // Allow decimal input
@@ -600,28 +640,38 @@ class InputFormState extends State<InputForm> {
                         },
                       ),
                       const SizedBox(height: 16),
-                      // BMI Input Field
-                      TextFormField(
-                        controller: _bmiController,
-                        keyboardType: const TextInputType.numberWithOptions(
-                          decimal: true,
-                        ), // Allow decimal input
-                        decoration: InputDecoration(
-                          labelText: 'BMI (kg/m²)',
-                          helperText: 'Automatically calculated when height and weight are set',
-                          helperMaxLines:  2,
-                          border: const OutlineInputBorder(),
-                        ),
-                        validator: (value) {
-                          // TODO MRB: validate up front (SDS validation as per Python package)
-                          if (value != null &&
-                              value.isNotEmpty &&
-                              double.tryParse(value) == null) {
-                            return 'Please enter a valid number';
-                          }
-                          return null; // Valid
-                        },
-                      ),
+                      // Derived BMI if height and weight set otherwise
+                      _heightController.text.isEmpty && _weightController.text.isEmpty && _ofcController.text.isEmpty
+                          ? // BMI Input Field
+                          TextFormField(
+                            controller: _bmiController,
+                            keyboardType: const TextInputType.numberWithOptions(
+                              decimal: true,
+                            ),
+                            decoration: InputDecoration(
+                              labelText: 'BMI (kg/m²)',
+                              border: const OutlineInputBorder(),
+                            ),
+                            validator: (value) {
+                              // TODO MRB: validate up front (SDS validation as per Python package)
+                              if (value != null &&
+                                  value.isNotEmpty &&
+                                  double.tryParse(value) == null) {
+                                return 'Please enter a valid number';
+                              }
+                              return null; // Valid
+                            },
+                          )
+                          : TextFormField(
+                            controller: _derivedBmiController,
+                              enabled: false,
+                              decoration: InputDecoration(
+                                labelText: 'BMI (kg/m²)',
+                                helperText: _weightController.text.isEmpty || _heightController.text.isEmpty ? 'Calculated automatically from weight and height' : '',
+                                helperMaxLines: 2,
+                                border: const OutlineInputBorder(),
+                              )
+                            )
                     ]
                   )
                 ),

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -115,23 +115,6 @@ class InputFormState extends State<InputForm> {
     }
   }
 
-  // Function to get the hint text for the measurement input based on the selected type
-  // TODO: MRB this advice inline
-  // String _getMeasurementHintText() {
-  //   switch (_selectedMeasurementMethod) {
-  //     case MeasurementMethod.height:
-  //       return 'Enter height in cm';
-  //     case MeasurementMethod.weight:
-  //       return 'Enter weight in kg';
-  //     case MeasurementMethod.ofc:
-  //       return 'Enter head circumference in cm';
-  //     case MeasurementMethod.bmi:
-  //       return 'Enter BMI in kg/m²';
-  //     case null:
-  //       return "";
-  //   }
-  // }
-
   void _resetForm() {
     _heightController.clear();
     _weightController.clear();
@@ -203,8 +186,11 @@ class InputFormState extends State<InputForm> {
       setState(() => _loading = true);
 
       final List<Future> tasks = [];
+      MeasurementMethod? firstMeasurementMethod = null;
 
       if (_heightController.text.isNotEmpty) {
+        firstMeasurementMethod ??= MeasurementMethod.height;
+
         tasks.add(
           appState.addMeasurement(
             observationDate: clinicDate,
@@ -215,6 +201,8 @@ class InputFormState extends State<InputForm> {
       }
 
       if (_weightController.text.isNotEmpty) {
+        firstMeasurementMethod ??= MeasurementMethod.weight;
+
         tasks.add(
           appState.addMeasurement(
             observationDate: clinicDate,
@@ -225,6 +213,8 @@ class InputFormState extends State<InputForm> {
       }
 
       if (_ofcController.text.isNotEmpty) {
+        firstMeasurementMethod ??= MeasurementMethod.ofc;
+
         tasks.add(
           appState.addMeasurement(
             observationDate: clinicDate,
@@ -245,7 +235,7 @@ class InputFormState extends State<InputForm> {
             context,
             MaterialPageRoute(
               builder: (context) =>
-                  ResultsPage(initialMeasurementMethod: measurementMethod),
+                  ResultsPage(initialMeasurementMethod: firstMeasurementMethod),
             ),
           );
         }

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -19,15 +19,11 @@ class InputFormState extends State<InputForm> {
   final TextEditingController _dobController = TextEditingController();
   final TextEditingController _observationDateController =
       TextEditingController();
-  final TextEditingController _measurementController = TextEditingController();
+  final TextEditingController _heightController = TextEditingController();
 
   // Variables to hold the selected dates (stored as DateTime objects for comparisons)
   DateTime? _selectedDob;
   DateTime? _selectedClinicDate;
-
-  // Variable to hold the selected measurement type
-  MeasurementMethod? _selectedMeasurementMethod =
-      MeasurementMethod.height; // Default to Height
 
   // Variable to hold the selected Sex
   Sex _selectedSex = Sex.male; // Default to Male
@@ -43,8 +39,7 @@ class InputFormState extends State<InputForm> {
     // Validate the form and update the _canSubmit state
     // The null check for currentState is important if the form might not be built yet.
     if (_formKey.currentState != null &&
-        _formKey.currentState!.validate() &&
-        _selectedMeasurementMethod != null) {
+        _formKey.currentState!.validate()) {
       if (!_canSubmit) {
         setState(() {
           _canSubmit = true;
@@ -119,29 +114,28 @@ class InputFormState extends State<InputForm> {
   }
 
   // Function to get the hint text for the measurement input based on the selected type
-  String _getMeasurementHintText() {
-    switch (_selectedMeasurementMethod) {
-      case MeasurementMethod.height:
-        return 'Enter height in cm';
-      case MeasurementMethod.weight:
-        return 'Enter weight in kg';
-      case MeasurementMethod.ofc:
-        return 'Enter head circumference in cm';
-      case MeasurementMethod.bmi:
-        return 'Enter BMI in kg/m²';
-      case null:
-        return "";
-    }
-  }
+  // TODO: MRB this advice inline
+  // String _getMeasurementHintText() {
+  //   switch (_selectedMeasurementMethod) {
+  //     case MeasurementMethod.height:
+  //       return 'Enter height in cm';
+  //     case MeasurementMethod.weight:
+  //       return 'Enter weight in kg';
+  //     case MeasurementMethod.ofc:
+  //       return 'Enter head circumference in cm';
+  //     case MeasurementMethod.bmi:
+  //       return 'Enter BMI in kg/m²';
+  //     case null:
+  //       return "";
+  //   }
+  // }
 
   void _resetForm() {
-    _measurementController.clear();
+    _heightController.clear();
 
     setState(() {
       // Don't reset the observation date, it's annoying to have to select it again
       // https://github.com/rcpch/digital-growth-charts-app/issues/21
-      // You do have to select the measurement type though to avoid mistakes
-      _selectedMeasurementMethod = null;
       _canSubmit = false;
     });
   }
@@ -151,15 +145,13 @@ class InputFormState extends State<InputForm> {
     appState.reset();
 
     _observationDateController.clear();
-    _measurementController.clear();
+    _heightController.clear();
     _dobController.clear();
     _selectedClinicDate = null;
     _selectedDob = null;
-    _selectedMeasurementMethod = MeasurementMethod.height;
     _selectedSex = Sex.male;
     setState(() {
       _selectedClinicDate = null;
-      _selectedMeasurementMethod = MeasurementMethod.height;
     });
   }
 
@@ -177,8 +169,10 @@ class InputFormState extends State<InputForm> {
 
       // Access the entered values:
       final String clinicDate = _observationDateController.text;
-      final String observationValue = _measurementController.text;
-      final MeasurementMethod measurementMethod = _selectedMeasurementMethod!;
+
+      // TODO MRB: build up measurements based on text boxes filled in
+      final String observationValue = _heightController.text;
+      final MeasurementMethod measurementMethod = MeasurementMethod.height; // Placeholder, replace with actual selected method
 
       if (appState.organizedGrowthData.isNotEmpty) {
         // If there's existing data, check if the current demographics match the fixed ones
@@ -261,7 +255,7 @@ class InputFormState extends State<InputForm> {
     // Clean up the controllers when the widget is disposed
     _dobController.dispose();
     _observationDateController.dispose();
-    _measurementController.dispose();
+    _heightController.dispose();
     super.dispose();
   }
 
@@ -494,47 +488,14 @@ class InputFormState extends State<InputForm> {
             const SizedBox(height: 16),
             // Spacing after Sex validation
 
-            // Measurement Type Radio Buttons
-            const Text(
-              'Select Measurement Type:',
-              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-            ),
-            EnumRadioGroup<MeasurementMethod>(
-              groupValue: _selectedMeasurementMethod,
-              enabled: true,
-              onChanged: (value) {
-                setState(() {
-                  _selectedMeasurementMethod = value!;
-                  _measurementController.clear();
-                });
-                _checkFormValidity();
-              },
-              values: MeasurementMethod.values, // all enum values
-              labelBuilder: (m) {
-                switch (m) {
-                  case MeasurementMethod.height:
-                    return 'Height';
-                  case MeasurementMethod.weight:
-                    return 'Weight';
-                  case MeasurementMethod.ofc:
-                    return 'Head Circ.';
-                  case MeasurementMethod.bmi:
-                    return 'BMI';
-                }
-              },
-              itemsPerRow: 2, // 2 radiobuttons per row
-            ),
-            const SizedBox(height: 16),
-
             // Measurement Input Field (Hint changes based on selection)
             TextFormField(
-              controller: _measurementController,
+              controller: _heightController,
               keyboardType: const TextInputType.numberWithOptions(
                 decimal: true,
               ), // Allow decimal input
               decoration: InputDecoration(
-                labelText: 'Measurement',
-                hintText: _getMeasurementHintText(), // Dynamic hint text
+                labelText: 'Height (cm)',
                 border: const OutlineInputBorder(),
               ),
               validator: (value) {

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -41,8 +41,7 @@ class InputFormState extends State<InputForm> {
   void _checkFormValidity() {
     // Validate the form and update the _canSubmit state
     // The null check for currentState is important if the form might not be built yet.
-    if (_formKey.currentState != null &&
-        _formKey.currentState!.validate()) {
+    if (_formKey.currentState != null && _formKey.currentState!.validate()) {
       if (!_canSubmit) {
         setState(() {
           _canSubmit = true;
@@ -179,7 +178,8 @@ class InputFormState extends State<InputForm> {
 
       // TODO MRB: build up measurements based on text boxes filled in
       final String observationValue = _heightController.text;
-      final MeasurementMethod measurementMethod = MeasurementMethod.height; // Placeholder, replace with actual selected method
+      final MeasurementMethod measurementMethod = MeasurementMethod
+          .height; // Placeholder, replace with actual selected method
 
       if (appState.organizedGrowthData.isNotEmpty) {
         // If there's existing data, check if the current demographics match the fixed ones
@@ -207,12 +207,40 @@ class InputFormState extends State<InputForm> {
 
       setState(() => _loading = true);
 
-      try {
-        await appState.addMeasurement(
-          observationDate: clinicDate,
-          method: measurementMethod,
-          value: observationValue,
+      final List<Future> tasks = [];
+
+      if (_heightController.text.isNotEmpty) {
+        tasks.add(
+          appState.addMeasurement(
+            observationDate: clinicDate,
+            method: MeasurementMethod.height,
+            value: _heightController.text,
+          ),
         );
+      }
+
+      if (_weightController.text.isNotEmpty) {
+        tasks.add(
+          appState.addMeasurement(
+            observationDate: clinicDate,
+            method: MeasurementMethod.weight,
+            value: _weightController.text,
+          ),
+        );
+      }
+
+      if (_ofcController.text.isNotEmpty) {
+        tasks.add(
+          appState.addMeasurement(
+            observationDate: clinicDate,
+            method: MeasurementMethod.ofc,
+            value: _ofcController.text,
+          ),
+        );
+      }
+
+      try {
+        await Future.wait(tasks);
 
         _resetForm();
 
@@ -505,7 +533,9 @@ class InputFormState extends State<InputForm> {
               ),
               validator: (value) {
                 // TODO MRB: validate up front (SDS validation as per Python package)
-                if (value != null && value.isNotEmpty && double.tryParse(value) == null) {
+                if (value != null &&
+                    value.isNotEmpty &&
+                    double.tryParse(value) == null) {
                   return 'Please enter a valid number';
                 }
                 return null; // Valid
@@ -526,7 +556,9 @@ class InputFormState extends State<InputForm> {
               ),
               validator: (value) {
                 // TODO MRB: validate up front (SDS validation as per Python package)
-                if (value != null && value.isNotEmpty && double.tryParse(value) == null) {
+                if (value != null &&
+                    value.isNotEmpty &&
+                    double.tryParse(value) == null) {
                   return 'Please enter a valid number';
                 }
                 return null; // Valid
@@ -547,7 +579,9 @@ class InputFormState extends State<InputForm> {
               ),
               validator: (value) {
                 // TODO MRB: validate up front (SDS validation as per Python package)
-                if (value != null && value.isNotEmpty && double.tryParse(value) == null) {
+                if (value != null &&
+                    value.isNotEmpty &&
+                    double.tryParse(value) == null) {
                   return 'Please enter a valid number';
                 }
                 return null; // Valid

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -23,6 +23,7 @@ class InputFormState extends State<InputForm> {
   final TextEditingController _heightController = TextEditingController();
   final TextEditingController _weightController = TextEditingController();
   final TextEditingController _ofcController = TextEditingController();
+  final TextEditingController _bmiController = TextEditingController();
 
   // Variables to hold the selected dates (stored as DateTime objects for comparisons)
   DateTime? _selectedDob;
@@ -47,7 +48,8 @@ class InputFormState extends State<InputForm> {
     final hasMeasurement =
         _heightController.text.isNotEmpty ||
         _weightController.text.isNotEmpty ||
-        _ofcController.text.isNotEmpty;
+        _ofcController.text.isNotEmpty ||
+        _bmiController.text.isNotEmpty;
     final canSubmit = formValid && hasMeasurement;
     if (canSubmit != _canSubmit) {
       setState(() {
@@ -119,6 +121,7 @@ class InputFormState extends State<InputForm> {
     _heightController.clear();
     _weightController.clear();
     _ofcController.clear();
+    _bmiController.clear();
 
     setState(() {
       // Don't reset the observation date, it's annoying to have to select it again
@@ -135,6 +138,7 @@ class InputFormState extends State<InputForm> {
     _heightController.clear();
     _weightController.clear();
     _ofcController.clear();
+    _bmiController.clear();
     _dobController.clear();
     _selectedClinicDate = null;
     _selectedDob = null;
@@ -186,7 +190,7 @@ class InputFormState extends State<InputForm> {
       setState(() => _loading = true);
 
       final List<Future> tasks = [];
-      MeasurementMethod? firstMeasurementMethod = null;
+      MeasurementMethod? firstMeasurementMethod;
 
       if (_heightController.text.isNotEmpty) {
         firstMeasurementMethod ??= MeasurementMethod.height;
@@ -220,6 +224,18 @@ class InputFormState extends State<InputForm> {
             observationDate: clinicDate,
             method: MeasurementMethod.ofc,
             value: _ofcController.text,
+          ),
+        );
+      }
+
+      if (_bmiController.text.isNotEmpty) {
+        firstMeasurementMethod ??= MeasurementMethod.bmi;
+
+        tasks.add(
+          appState.addMeasurement(
+            observationDate: clinicDate,
+            method: MeasurementMethod.bmi,
+            value: _bmiController.text,
           ),
         );
       }
@@ -278,6 +294,7 @@ class InputFormState extends State<InputForm> {
     _heightController.dispose();
     _weightController.dispose();
     _ofcController.dispose();
+    _bmiController.dispose();
     super.dispose();
   }
 
@@ -554,28 +571,61 @@ class InputFormState extends State<InputForm> {
             ExpansionTile(
               title: const Text('Other measurement types'),
               children: [
-                const SizedBox(height: 8),
-                // Head Circumference (ofc) Input Field
-                TextFormField(
-                  controller: _ofcController,
-                  keyboardType: const TextInputType.numberWithOptions(
-                    decimal: true,
-                  ), // Allow decimal input
-                  decoration: InputDecoration(
-                    labelText: 'Head Circumference (cm)',
-                    border: const OutlineInputBorder(),
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16.0,
+                    vertical: 16.0,
                   ),
-                  validator: (value) {
-                    // TODO MRB: validate up front (SDS validation as per Python package)
-                    if (value != null &&
-                        value.isNotEmpty &&
-                        double.tryParse(value) == null) {
-                      return 'Please enter a valid number';
-                    }
-                    return null; // Valid
-                  },
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Head Circumference (ofc) Input Field
+                      TextFormField(
+                        controller: _ofcController,
+                        keyboardType: const TextInputType.numberWithOptions(
+                          decimal: true,
+                        ), // Allow decimal input
+                        decoration: InputDecoration(
+                          labelText: 'Head Circumference (cm)',
+                          border: const OutlineInputBorder(),
+                        ),
+                        validator: (value) {
+                          // TODO MRB: validate up front (SDS validation as per Python package)
+                          if (value != null &&
+                              value.isNotEmpty &&
+                              double.tryParse(value) == null) {
+                            return 'Please enter a valid number';
+                          }
+                          return null; // Valid
+                        },
+                      ),
+                      const SizedBox(height: 16),
+                      // BMI Input Field
+                      TextFormField(
+                        controller: _bmiController,
+                        keyboardType: const TextInputType.numberWithOptions(
+                          decimal: true,
+                        ), // Allow decimal input
+                        decoration: InputDecoration(
+                          labelText: 'BMI (kg/m²)',
+                          helperText: 'Automatically calculated when height and weight are set',
+                          helperMaxLines:  2,
+                          border: const OutlineInputBorder(),
+                        ),
+                        validator: (value) {
+                          // TODO MRB: validate up front (SDS validation as per Python package)
+                          if (value != null &&
+                              value.isNotEmpty &&
+                              double.tryParse(value) == null) {
+                            return 'Please enter a valid number';
+                          }
+                          return null; // Valid
+                        },
+                      ),
+                    ]
+                  )
                 ),
-              ],
+              ]
             ),
 
             const SizedBox(height: 24),

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -1,5 +1,6 @@
 import 'dart:developer' as developer;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 // RCPCH imports
 import 'package:digital_growth_charts_app/themes/colours.dart';
@@ -20,6 +21,8 @@ class InputFormState extends State<InputForm> {
   final TextEditingController _observationDateController =
       TextEditingController();
   final TextEditingController _heightController = TextEditingController();
+  final TextEditingController _weightController = TextEditingController();
+  final TextEditingController _ofcController = TextEditingController();
 
   // Variables to hold the selected dates (stored as DateTime objects for comparisons)
   DateTime? _selectedDob;
@@ -132,6 +135,8 @@ class InputFormState extends State<InputForm> {
 
   void _resetForm() {
     _heightController.clear();
+    _weightController.clear();
+    _ofcController.clear();
 
     setState(() {
       // Don't reset the observation date, it's annoying to have to select it again
@@ -146,6 +151,8 @@ class InputFormState extends State<InputForm> {
 
     _observationDateController.clear();
     _heightController.clear();
+    _weightController.clear();
+    _ofcController.clear();
     _dobController.clear();
     _selectedClinicDate = null;
     _selectedDob = null;
@@ -256,6 +263,8 @@ class InputFormState extends State<InputForm> {
     _dobController.dispose();
     _observationDateController.dispose();
     _heightController.dispose();
+    _weightController.dispose();
+    _ofcController.dispose();
     super.dispose();
   }
 
@@ -453,10 +462,6 @@ class InputFormState extends State<InputForm> {
             // --- End of New Gestation Section ---
 
             // Sex Radio Buttons
-            const Text(
-              'Select Sex:',
-              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-            ),
             EnumRadioGroup<Sex>(
               groupValue: _selectedSex,
               onChanged: (value) {
@@ -488,7 +493,7 @@ class InputFormState extends State<InputForm> {
             const SizedBox(height: 16),
             // Spacing after Sex validation
 
-            // Measurement Input Field (Hint changes based on selection)
+            // Height Input Field
             TextFormField(
               controller: _heightController,
               keyboardType: const TextInputType.numberWithOptions(
@@ -499,17 +504,56 @@ class InputFormState extends State<InputForm> {
                 border: const OutlineInputBorder(),
               ),
               validator: (value) {
-                if (value == null || value.isEmpty) {
-                  return 'Please enter a measurement value';
-                }
-                // You could add more specific validation here based on MeasurementMethod (e.g., check if it's a valid number, within a reasonable range)
-                // Example: check if it's a number
-                if (double.tryParse(value) == null) {
+                // TODO MRB: validate up front (SDS validation as per Python package)
+                if (value != null && value.isNotEmpty && double.tryParse(value) == null) {
                   return 'Please enter a valid number';
                 }
                 return null; // Valid
               },
             ),
+            const SizedBox(height: 16),
+            // Spacing after Height validation
+
+            // Weight Input Field
+            TextFormField(
+              controller: _weightController,
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+              ), // Allow decimal input
+              decoration: InputDecoration(
+                labelText: 'Weight (kg)',
+                border: const OutlineInputBorder(),
+              ),
+              validator: (value) {
+                // TODO MRB: validate up front (SDS validation as per Python package)
+                if (value != null && value.isNotEmpty && double.tryParse(value) == null) {
+                  return 'Please enter a valid number';
+                }
+                return null; // Valid
+              },
+            ),
+            const SizedBox(height: 16),
+            // Spacing after Weight validation
+
+            // Head Circumference (ofc) Input Field
+            TextFormField(
+              controller: _ofcController,
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+              ), // Allow decimal input
+              decoration: InputDecoration(
+                labelText: 'Head Circumference (cm)',
+                border: const OutlineInputBorder(),
+              ),
+              validator: (value) {
+                // TODO MRB: validate up front (SDS validation as per Python package)
+                if (value != null && value.isNotEmpty && double.tryParse(value) == null) {
+                  return 'Please enter a valid number';
+                }
+                return null; // Valid
+              },
+            ),
+
             const SizedBox(height: 24),
 
             // Submit Button

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -61,7 +61,8 @@ class InputFormState extends State<InputForm> {
   }
 
   void _updateBmi() {
-    if (_heightController.text.isNotEmpty && _weightController.text.isNotEmpty) {
+    if (_heightController.text.isNotEmpty &&
+        _weightController.text.isNotEmpty) {
       final height = double.tryParse(_heightController.text);
       final weight = double.tryParse(_weightController.text);
       if (height != null && weight != null) {
@@ -258,7 +259,8 @@ class InputFormState extends State<InputForm> {
             value: _bmiController.text,
           ),
         );
-      } else if(_weightController.text.isNotEmpty && _heightController.text.isNotEmpty) {
+      } else if (_weightController.text.isNotEmpty &&
+          _heightController.text.isNotEmpty) {
         final bmi = calculateBmi(
           double.tryParse(_weightController.text) ?? 0,
           double.tryParse(_heightController.text) ?? 0,
@@ -641,41 +643,48 @@ class InputFormState extends State<InputForm> {
                       ),
                       const SizedBox(height: 16),
                       // Derived BMI if height and weight set otherwise
-                      _heightController.text.isEmpty && _weightController.text.isEmpty && _ofcController.text.isEmpty
+                      _heightController.text.isEmpty &&
+                              _weightController.text.isEmpty &&
+                              _ofcController.text.isEmpty
                           ? // BMI Input Field
-                          TextFormField(
-                            controller: _bmiController,
-                            keyboardType: const TextInputType.numberWithOptions(
-                              decimal: true,
-                            ),
-                            decoration: InputDecoration(
-                              labelText: 'BMI (kg/m²)',
-                              border: const OutlineInputBorder(),
-                            ),
-                            validator: (value) {
-                              // TODO MRB: validate up front (SDS validation as per Python package)
-                              if (value != null &&
-                                  value.isNotEmpty &&
-                                  double.tryParse(value) == null) {
-                                return 'Please enter a valid number';
-                              }
-                              return null; // Valid
-                            },
-                          )
+                            TextFormField(
+                              controller: _bmiController,
+                              keyboardType:
+                                  const TextInputType.numberWithOptions(
+                                    decimal: true,
+                                  ),
+                              decoration: InputDecoration(
+                                labelText: 'BMI (kg/m²)',
+                                border: const OutlineInputBorder(),
+                              ),
+                              validator: (value) {
+                                // TODO MRB: validate up front (SDS validation as per Python package)
+                                if (value != null &&
+                                    value.isNotEmpty &&
+                                    double.tryParse(value) == null) {
+                                  return 'Please enter a valid number';
+                                }
+                                return null; // Valid
+                              },
+                            )
                           : TextFormField(
-                            controller: _derivedBmiController,
+                              controller: _derivedBmiController,
                               enabled: false,
                               decoration: InputDecoration(
                                 labelText: 'BMI (kg/m²)',
-                                helperText: _weightController.text.isEmpty || _heightController.text.isEmpty ? 'Calculated automatically from weight and height' : '',
+                                helperText:
+                                    _weightController.text.isEmpty ||
+                                        _heightController.text.isEmpty
+                                    ? 'Calculated automatically from weight and height'
+                                    : '',
                                 helperMaxLines: 2,
                                 border: const OutlineInputBorder(),
-                              )
-                            )
-                    ]
-                  )
+                              ),
+                            ),
+                    ],
+                  ),
                 ),
-              ]
+              ],
             ),
 
             const SizedBox(height: 24),

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -41,18 +41,17 @@ class InputFormState extends State<InputForm> {
   void _checkFormValidity() {
     // Validate the form and update the _canSubmit state
     // The null check for currentState is important if the form might not be built yet.
-    if (_formKey.currentState != null && _formKey.currentState!.validate()) {
-      if (!_canSubmit) {
-        setState(() {
-          _canSubmit = true;
-        });
-      }
-    } else {
-      if (_canSubmit) {
-        setState(() {
-          _canSubmit = false;
-        });
-      }
+    final formValid =
+        _formKey.currentState != null && _formKey.currentState!.validate();
+    // At least one measurement (height, weight, or OFC) must be supplied.
+    final hasMeasurement = _heightController.text.isNotEmpty ||
+        _weightController.text.isNotEmpty ||
+        _ofcController.text.isNotEmpty;
+    final canSubmit = formValid && hasMeasurement;
+    if (canSubmit != _canSubmit) {
+      setState(() {
+        _canSubmit = canSubmit;
+      });
     }
   }
 

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -44,7 +44,8 @@ class InputFormState extends State<InputForm> {
     final formValid =
         _formKey.currentState != null && _formKey.currentState!.validate();
     // At least one measurement (height, weight, or OFC) must be supplied.
-    final hasMeasurement = _heightController.text.isNotEmpty ||
+    final hasMeasurement =
+        _heightController.text.isNotEmpty ||
         _weightController.text.isNotEmpty ||
         _ofcController.text.isNotEmpty;
     final canSubmit = formValid && hasMeasurement;
@@ -369,7 +370,7 @@ class InputFormState extends State<InputForm> {
 
             // --- Start of New Gestation Section ---
             ExpansionTile(
-              title: const Text('Add Gestation if Known'),
+              title: const Text('Add gestation if known'),
               onExpansionChanged: (bool expanded) {
                 setState(() {
                   _showGestationFields = expanded;
@@ -380,7 +381,7 @@ class InputFormState extends State<InputForm> {
                 Padding(
                   padding: const EdgeInsets.symmetric(
                     horizontal: 16.0,
-                    vertical: 8.0,
+                    vertical: 16.0,
                   ),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -470,7 +471,6 @@ class InputFormState extends State<InputForm> {
                 ),
               ],
             ),
-            const SizedBox(height: 16),
             // --- End of New Gestation Section ---
 
             // Sex Radio Buttons
@@ -502,7 +502,7 @@ class InputFormState extends State<InputForm> {
                 return const SizedBox.shrink(); // Hide the error message when a Sex is selected or form not validated yet
               },
             ),
-            const SizedBox(height: 16),
+            const SizedBox(height: 8),
             // Spacing after Sex validation
 
             // Height Input Field
@@ -551,25 +551,31 @@ class InputFormState extends State<InputForm> {
             const SizedBox(height: 16),
             // Spacing after Weight validation
 
-            // Head Circumference (ofc) Input Field
-            TextFormField(
-              controller: _ofcController,
-              keyboardType: const TextInputType.numberWithOptions(
-                decimal: true,
-              ), // Allow decimal input
-              decoration: InputDecoration(
-                labelText: 'Head Circumference (cm)',
-                border: const OutlineInputBorder(),
-              ),
-              validator: (value) {
-                // TODO MRB: validate up front (SDS validation as per Python package)
-                if (value != null &&
-                    value.isNotEmpty &&
-                    double.tryParse(value) == null) {
-                  return 'Please enter a valid number';
-                }
-                return null; // Valid
-              },
+            ExpansionTile(
+              title: const Text('Other measurement types'),
+              children: [
+                const SizedBox(height: 8),
+                // Head Circumference (ofc) Input Field
+                TextFormField(
+                  controller: _ofcController,
+                  keyboardType: const TextInputType.numberWithOptions(
+                    decimal: true,
+                  ), // Allow decimal input
+                  decoration: InputDecoration(
+                    labelText: 'Head Circumference (cm)',
+                    border: const OutlineInputBorder(),
+                  ),
+                  validator: (value) {
+                    // TODO MRB: validate up front (SDS validation as per Python package)
+                    if (value != null &&
+                        value.isNotEmpty &&
+                        double.tryParse(value) == null) {
+                      return 'Please enter a valid number';
+                    }
+                    return null; // Valid
+                  },
+                ),
+              ],
             ),
 
             const SizedBox(height: 24),

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -176,11 +176,6 @@ class InputFormState extends State<InputForm> {
       // Access the entered values:
       final String clinicDate = _observationDateController.text;
 
-      // TODO MRB: build up measurements based on text boxes filled in
-      final String observationValue = _heightController.text;
-      final MeasurementMethod measurementMethod = MeasurementMethod
-          .height; // Placeholder, replace with actual selected method
-
       if (appState.organizedGrowthData.isNotEmpty) {
         // If there's existing data, check if the current demographics match the fixed ones
         if (_selectedDob != appState.dob ||


### PR DESCRIPTION
Update the input form so you can enter height, weight and head circumference all at the same time. BMI is automatically derived once height and weight are set. You can still enter just BMI alone if you want. Also update the input labels so you can always see what unit for the data.

**Before**

[Screencast_20260814_203544.webm](https://github.com/user-attachments/assets/cbd2ff44-b804-4271-9611-36fe715d4ac5)

**After**

[Screencast_20260814_203806.webm](https://github.com/user-attachments/assets/add4efec-c90c-442f-a104-3f89c2409df6)

**After (single shot BMI)**

[Screencast_20260814_203909.webm](https://github.com/user-attachments/assets/afaf517f-7cf2-449d-ae28-b2f5e07c7880)

Fixes #69 
Address [this feedback](https://github.com/rcpch/digital-growth-charts-app/issues/65#issuecomment-4992709457), working towards #65
Part of #19 (single shot BMI but no plotting yet) 
Addresses the first two pieces of feedback in https://github.com/rcpch/digital-growth-charts-app/issues/66 
