### PR TITLE
Generate fictional child data

### DIFF
--- a/lib/classes/app_state.dart
+++ b/lib/classes/app_state.dart
@@ -115,6 +115,30 @@ class AppState with ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> generateFictionalData({
+    required int gestationWeeks,
+    required int gestationDays,
+    required Sex sex,
+    required double startChronologicalAge,
+    required double endAge,
+    required double measurementIntervalNumber,
+    required String measurementIntervalType,
+    required MeasurementMethod measurementMethod,
+  }) async {
+    final apiResponse = await _dgcApi.generateFictionalChildData(
+      gestationWeeks: gestationWeeks,
+      gestationDays: gestationDays,
+      sex: sex,
+      startChronologicalAge: startChronologicalAge,
+      endAge: endAge,
+      measurementIntervalNumber: measurementIntervalNumber,
+      measurementIntervalType: measurementIntervalType,
+      measurementMethod: measurementMethod,
+    );
+
+    print('Generated fictional data for $measurementMethod: ${apiResponse.length} entries');
+  }
+
   bool isFeatureFlagEnabled(FeatureFlag flag) {
     return _featureFlags.contains(flag);
   }

--- a/lib/classes/app_state.dart
+++ b/lib/classes/app_state.dart
@@ -155,9 +155,7 @@ class AppState with ChangeNotifier {
 
     await _fetchCentileDataIfNeeded(measurementMethod);
 
-    print(
-      'Generated fictional data for $measurementMethod: ${apiResponse.length} entries',
-    );
+    notifyListeners();
   }
 
   bool isFeatureFlagEnabled(FeatureFlag flag) {

--- a/lib/classes/app_state.dart
+++ b/lib/classes/app_state.dart
@@ -61,6 +61,28 @@ class AppState with ChangeNotifier {
 
   AuthData? get authData => _authData;
 
+  Future<void> _fetchCentileDataIfNeeded(MeasurementMethod method) async {
+    final bool isCentileDataCached =
+        _organizedCentileLines[_sex!]?.containsKey(method) ?? false;
+
+    if (!isCentileDataCached) {
+      final apiResponse = await _dgcApi.getChartCoordinates(
+        sex: _sex!,
+        measurementMethod: method,
+      );
+
+      // Process and merge the new centile data into the organized map
+      if (apiResponse.centileData != null) {
+        final newOrganizedData = organizeCentileLines(apiResponse);
+        // Merge new data. Prioritize new data for the same sex and measurement method
+        if (newOrganizedData[_sex!]?.containsKey(method) ?? false) {
+          _organizedCentileLines[_sex!]![method] =
+              newOrganizedData[_sex!]![method]!;
+        }
+      }
+    }
+  }
+
   Future<void> addMeasurement({
     required String observationDate,
     required MeasurementMethod method,
@@ -84,25 +106,7 @@ class AppState with ChangeNotifier {
       observationValue: value,
     );
 
-    final bool isCentileDataCached =
-        _organizedCentileLines[_sex!]?.containsKey(method) ?? false;
-
-    if (!isCentileDataCached) {
-      final apiResponse = await _dgcApi.getChartCoordinates(
-        sex: _sex!,
-        measurementMethod: method,
-      );
-
-      // Process and merge the new centile data into the organized map
-      if (apiResponse.centileData != null) {
-        final newOrganizedData = organizeCentileLines(apiResponse);
-        // Merge new data. Prioritize new data for the same sex and measurement method
-        if (newOrganizedData[_sex!]?.containsKey(method) ?? false) {
-          _organizedCentileLines[_sex!]![method] =
-              newOrganizedData[_sex!]![method]!;
-        }
-      }
-    }
+    await _fetchCentileDataIfNeeded(method);
 
     final apiResponse = await futureApiResponse;
 
@@ -136,7 +140,24 @@ class AppState with ChangeNotifier {
       measurementMethod: measurementMethod,
     );
 
-    print('Generated fictional data for $measurementMethod: ${apiResponse.length} entries');
+    _sex = sex;
+    _gestationWeeks = gestationWeeks;
+    _gestationDays = gestationDays;
+
+    final birthDateStr = apiResponse[0].birthData?.birthDate;
+    if (birthDateStr == null) {
+      throw Exception('Generated fictional data is missing birth_date');
+    }
+    _dob = DateFormat('yyyy-MM-dd').parse(birthDateStr);
+
+    _organizedGrowthData.clear();
+    _organizedGrowthData[measurementMethod] = apiResponse;
+
+    await _fetchCentileDataIfNeeded(measurementMethod);
+
+    print(
+      'Generated fictional data for $measurementMethod: ${apiResponse.length} entries',
+    );
   }
 
   bool isFeatureFlagEnabled(FeatureFlag flag) {

--- a/lib/services/digital_growth_charts_services.dart
+++ b/lib/services/digital_growth_charts_services.dart
@@ -187,7 +187,8 @@ class DigitalGrowthChartsService {
       if (response.statusCode == 200) {
         final List<dynamic> responseData = jsonDecode(response.body);
 
-        return responseData.map((item) => GrowthDataResponse.fromJson(item))
+        return responseData
+            .map((item) => GrowthDataResponse.fromJson(item))
             .toList();
       } else {
         developer.log(

--- a/lib/services/digital_growth_charts_services.dart
+++ b/lib/services/digital_growth_charts_services.dart
@@ -146,39 +146,105 @@ class DigitalGrowthChartsService {
       rethrow;
     }
   }
-}
 
-String parseApiError(String responseBody, int statusCode) {
-  try {
-    if (responseBody.isEmpty) {
-      return 'API Error: Status Code $statusCode (No response body)';
+  Future<List<GrowthDataResponse>> generateFictionalChildData({
+    required int gestationWeeks,
+    required int gestationDays,
+    required Sex sex,
+    required double startChronologicalAge,
+    required double endAge,
+    required double measurementIntervalNumber,
+    required String measurementIntervalType,
+    required MeasurementMethod measurementMethod,
+  }) async {
+    final url = Uri.parse(
+      '$_baseUrl/uk-who/fictional-child-data',
+    ); // Adjust the endpoint if needed
+    final String measurementMethodString = measurementMethod.name;
+    final String sexString = sex.name;
+
+    final Map<String, dynamic> requestBody = {
+      'gestation_weeks': gestationWeeks,
+      'gestation_days': gestationDays,
+      'sex': sexString,
+      'start_chronological_age': startChronologicalAge,
+      'end_age': endAge,
+      'measurement_interval_number': measurementIntervalNumber,
+      'measurement_interval_type': measurementIntervalType,
+      'measurement_method': measurementMethodString,
+    };
+
+    try {
+      final response = await http.post(
+        url,
+        headers: <String, String>{
+          'Content-Type': 'application/json; charset=UTF-8',
+          'Subscription-Key': _apiKey,
+        },
+        body: jsonEncode(requestBody),
+      );
+
+      if (response.statusCode == 200) {
+        final List<dynamic> responseData = jsonDecode(response.body);
+
+        return responseData.map((item) => GrowthDataResponse.fromJson(item))
+            .toList();
+      } else {
+        developer.log(
+          'Failed to generate fictional child data: ${response.statusCode}',
+          level: LogLevel.warning,
+          name: 'DigitalGrowthChartsService',
+          error: response.body,
+          stackTrace: StackTrace.current,
+        );
+        throw Exception(
+          'Failed to generate fictional child data: ${response.statusCode} - ${response.body}',
+        );
+      }
+    } catch (e) {
+      developer.log(
+        'Error generating fictional child data: $e',
+        level: LogLevel.severe,
+        name: 'DigitalGrowthChartsService',
+        error: e,
+        stackTrace: StackTrace.current,
+      );
+      rethrow;
     }
+  }
 
-    final Map<String, dynamic> errorJson = jsonDecode(responseBody);
+  String parseApiError(String responseBody, int statusCode) {
+    try {
+      if (responseBody.isEmpty) {
+        return 'API Error: Status Code $statusCode (No response body)';
+      }
 
-    if (errorJson.containsKey('detail') && errorJson['detail'] is List) {
-      final List<dynamic> detailList = errorJson['detail'] as List<dynamic>;
-      if (detailList.isNotEmpty) {
-        final firstErrorObject = detailList[0];
-        if (firstErrorObject is Map<String, dynamic> &&
-            firstErrorObject.containsKey('msg')) {
-          // Successfully extracted the specific message
-          return firstErrorObject['msg'].toString(); // Ensure it's a string
+      final Map<String, dynamic> errorJson = jsonDecode(responseBody);
+
+      if (errorJson.containsKey('detail') && errorJson['detail'] is List) {
+        final List<dynamic> detailList = errorJson['detail'] as List<dynamic>;
+        if (detailList.isNotEmpty) {
+          final firstErrorObject = detailList[0];
+          if (firstErrorObject is Map<String, dynamic> &&
+              firstErrorObject.containsKey('msg')) {
+            // Successfully extracted the specific message
+            return firstErrorObject['msg'].toString(); // Ensure it's a string
+          }
         }
       }
+      // If the specific 'msg' isn't found in the expected structure,
+      // return a more generic message including the status code and a hint of the body.
+      // You might want to truncate responseBody if it's too long for an exception message.
+      String truncatedBody = responseBody.length > 100
+          ? '${responseBody.substring(0, 100)}...'
+          : responseBody;
+      return 'API Error ($statusCode): Unexpected error format. Response: $truncatedBody';
+    } catch (e) {
+      // If JSON decoding fails or any other error during parsing
+      String truncatedBody = responseBody.length > 100
+          ? '${responseBody.substring(0, 100)}...'
+          : responseBody;
+      return 'API Error ($statusCode): Could not parse error response. Raw response: $truncatedBody';
     }
-    // If the specific 'msg' isn't found in the expected structure,
-    // return a more generic message including the status code and a hint of the body.
-    // You might want to truncate responseBody if it's too long for an exception message.
-    String truncatedBody = responseBody.length > 100
-        ? '${responseBody.substring(0, 100)}...'
-        : responseBody;
-    return 'API Error ($statusCode): Unexpected error format. Response: $truncatedBody';
-  } catch (e) {
-    // If JSON decoding fails or any other error during parsing
-    String truncatedBody = responseBody.length > 100
-        ? '${responseBody.substring(0, 100)}...'
-        : responseBody;
-    return 'API Error ($statusCode): Could not parse error response. Raw response: $truncatedBody';
   }
 }

--- a/lib/widgets/generator.dart
+++ b/lib/widgets/generator.dart
@@ -9,7 +9,7 @@ import '../classes/app_state.dart';
 class GeneratorFormState extends State<GeneratorForm> {
   // A GlobalKey to uniquely identify the Form widget
   final _formKey = GlobalKey<FormState>();
-  bool _canSubmit = false;
+  bool _canSubmit = true;
 
   final List<String> _ageUnits = ['Years', 'Months', 'Weeks', 'Days'];
 
@@ -17,13 +17,13 @@ class GeneratorFormState extends State<GeneratorForm> {
   int _selectedGestationDays = 0;
   Sex _selectedSex = Sex.male;
 
-  final TextEditingController _startAge = TextEditingController();
+  final TextEditingController _startAge = TextEditingController(text: '0');
   String _startAgeUnit = 'Years';
 
-  final TextEditingController _endAge = TextEditingController();
+  final TextEditingController _endAge = TextEditingController(text: '20');
   String _endAgeUnit = 'Years';
 
-  final TextEditingController _interval = TextEditingController();
+  final TextEditingController _interval = TextEditingController(text: '1');
   String _intervalUnit = 'Years';
 
   bool _loading = false;
@@ -184,6 +184,7 @@ class GeneratorFormState extends State<GeneratorForm> {
                         fontWeight: FontWeight.bold,
                       ),
                     ),
+                    const SizedBox(height: 16),
                     Row(
                       children: [
                         Expanded(
@@ -224,6 +225,7 @@ class GeneratorFormState extends State<GeneratorForm> {
                         // ),
                       ],
                     ),
+                    const SizedBox(height: 16),
                     Row(
                       children: [
                         Expanded(
@@ -264,6 +266,7 @@ class GeneratorFormState extends State<GeneratorForm> {
                         // ),
                       ],
                     ),
+                    const SizedBox(height: 16),
                     Row(
                       children: [
                         Expanded(

--- a/lib/widgets/generator.dart
+++ b/lib/widgets/generator.dart
@@ -63,6 +63,8 @@ class GeneratorFormState extends State<GeneratorForm> {
       measurementMethod: _measurementMethod,
     );
 
+    if (!mounted) return;
+
     Navigator.pushAndRemoveUntil(
       context,
       MaterialPageRoute(

--- a/lib/widgets/generator.dart
+++ b/lib/widgets/generator.dart
@@ -61,12 +61,13 @@ class GeneratorFormState extends State<GeneratorForm> {
       measurementMethod: _measurementMethod,
     );
 
-    Navigator.push(
+    Navigator.pushAndRemoveUntil(
       context,
       MaterialPageRoute(
         builder: (context) =>
             ResultsPage(initialMeasurementMethod: _measurementMethod),
       ),
+      (route) => route.isFirst,
     );
   }
 

--- a/lib/widgets/generator.dart
+++ b/lib/widgets/generator.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import '../definitions/enums.dart';
 import '../widgets/enum_radio_group.dart';
 import '../classes/app_state.dart';
+import './results.dart';
 
 class GeneratorFormState extends State<GeneratorForm> {
   // A GlobalKey to uniquely identify the Form widget
@@ -49,7 +50,7 @@ class GeneratorFormState extends State<GeneratorForm> {
 
     var appState = Provider.of<AppState>(context, listen: false);
 
-    appState.generateFictionalData(
+    await appState.generateFictionalData(
       gestationWeeks: _selectedGestationWeeks,
       gestationDays: _selectedGestationDays,
       sex: _selectedSex,
@@ -58,6 +59,14 @@ class GeneratorFormState extends State<GeneratorForm> {
       measurementIntervalNumber: double.parse(_interval.text),
       measurementIntervalType: _intervalUnit.toLowerCase(),
       measurementMethod: _measurementMethod,
+    );
+
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) =>
+            ResultsPage(initialMeasurementMethod: _measurementMethod),
+      ),
     );
   }
 

--- a/lib/widgets/generator.dart
+++ b/lib/widgets/generator.dart
@@ -86,8 +86,6 @@ class GeneratorFormState extends State<GeneratorForm> {
 
   @override
   Widget build(BuildContext context) {
-    var appState = context.watch<AppState>();
-
     return Scaffold(
       appBar: AppBar(title: const Text('Generate data')),
       body: SafeArea(
@@ -138,9 +136,7 @@ class GeneratorFormState extends State<GeneratorForm> {
                                       );
                                     })
                                     .toList(),
-                            onChanged: appState.organizedGrowthData.isNotEmpty
-                                ? null
-                                : (int? newValue) {
+                            onChanged: (int? newValue) {
                                     if (newValue != null) {
                                       setState(() {
                                         _selectedGestationWeeks = newValue;
@@ -173,9 +169,7 @@ class GeneratorFormState extends State<GeneratorForm> {
                                       );
                                     })
                                     .toList(),
-                            onChanged: appState.organizedGrowthData.isNotEmpty
-                                ? null
-                                : (int? newValue) {
+                            onChanged: (int? newValue) {
                                     if (newValue != null) {
                                       setState(() {
                                         _selectedGestationDays = newValue;
@@ -205,7 +199,6 @@ class GeneratorFormState extends State<GeneratorForm> {
                           });
                           _checkFormValidity();
                         },
-                        enabled: appState.organizedGrowthData.isEmpty,
                         values: Sex.values,
                         labelBuilder: (m) {
                           switch (m) {
@@ -354,7 +347,6 @@ class GeneratorFormState extends State<GeneratorForm> {
                           });
                           _checkFormValidity();
                         },
-                        enabled: appState.organizedGrowthData.isEmpty,
                         values: MeasurementMethod.values,
                         labelBuilder: _measurementMethodToString
                       ),

--- a/lib/widgets/generator.dart
+++ b/lib/widgets/generator.dart
@@ -96,295 +96,302 @@ class GeneratorFormState extends State<GeneratorForm> {
             children: [
               Expanded(
                 child: Form(
-                // Wrap form content in a Form widget
-                key: _formKey, // Assign the GlobalKey
-                autovalidateMode: AutovalidateMode.onUserInteraction,
-                onChanged: () {
-                  setState(() {
-                    _canSubmit = _formKey.currentState?.validate() ?? false;
-                  });
-                  _checkFormValidity();
-                },
-                child: SingleChildScrollView(
-                  // Add SingleChildScrollView to prevent overflow on smaller screens
-                  padding: const EdgeInsets.all(16.0),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: <Widget>[
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const Text(
-                            'Gestation Weeks:',
-                            style: TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.bold,
+                  // Wrap form content in a Form widget
+                  key: _formKey, // Assign the GlobalKey
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
+                  onChanged: () {
+                    setState(() {
+                      _canSubmit = _formKey.currentState?.validate() ?? false;
+                    });
+                    _checkFormValidity();
+                  },
+                  child: SingleChildScrollView(
+                    // Add SingleChildScrollView to prevent overflow on smaller screens
+                    padding: const EdgeInsets.all(16.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: <Widget>[
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Text(
+                              'Gestation Weeks:',
+                              style: TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.bold,
+                              ),
                             ),
-                          ),
-                          DropdownButtonFormField<int>(
-                            decoration: const InputDecoration(
-                              border: OutlineInputBorder(),
+                            DropdownButtonFormField<int>(
+                              decoration: const InputDecoration(
+                                border: OutlineInputBorder(),
+                              ),
+                              initialValue: _selectedGestationWeeks,
+                              items:
+                                  List.generate(
+                                        19,
+                                        (index) => index + 24,
+                                      ) // Weeks 24 to 42
+                                      .map((int weeks) {
+                                        return DropdownMenuItem<int>(
+                                          value: weeks,
+                                          child: Text('$weeks'),
+                                        );
+                                      })
+                                      .toList(),
+                              onChanged: (int? newValue) {
+                                if (newValue != null) {
+                                  setState(() {
+                                    _selectedGestationWeeks = newValue;
+                                  });
+                                }
+                              },
+                              validator: (value) {
+                                return null;
+                              },
                             ),
-                            initialValue: _selectedGestationWeeks,
-                            items:
-                                List.generate(
-                                      19,
-                                      (index) => index + 24,
-                                    ) // Weeks 24 to 42
-                                    .map((int weeks) {
-                                      return DropdownMenuItem<int>(
-                                        value: weeks,
-                                        child: Text('$weeks'),
-                                      );
-                                    })
-                                    .toList(),
-                            onChanged: (int? newValue) {
-                                    if (newValue != null) {
-                                      setState(() {
-                                        _selectedGestationWeeks = newValue;
-                                      });
-                                    }
-                                  },
-                            validator: (value) {
-                              return null;
-                            },
-                          ),
-                          const SizedBox(height: 16),
-                          const Text(
-                            'Gestation Days:',
-                            style: TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.bold,
+                            const SizedBox(height: 16),
+                            const Text(
+                              'Gestation Days:',
+                              style: TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.bold,
+                              ),
                             ),
-                          ),
-                          DropdownButtonFormField<int>(
-                            decoration: const InputDecoration(
-                              border: OutlineInputBorder(),
+                            DropdownButtonFormField<int>(
+                              decoration: const InputDecoration(
+                                border: OutlineInputBorder(),
+                              ),
+                              initialValue: _selectedGestationDays,
+                              items:
+                                  List.generate(
+                                        7,
+                                        (index) => index,
+                                      ) // Days 0 to 6
+                                      .map((int days) {
+                                        return DropdownMenuItem<int>(
+                                          value: days,
+                                          child: Text('$days'),
+                                        );
+                                      })
+                                      .toList(),
+                              onChanged: (int? newValue) {
+                                if (newValue != null) {
+                                  setState(() {
+                                    _selectedGestationDays = newValue;
+                                  });
+                                }
+                              },
+                              validator: (value) {
+                                return null;
+                              },
                             ),
-                            initialValue: _selectedGestationDays,
-                            items:
-                                List.generate(7, (index) => index) // Days 0 to 6
-                                    .map((int days) {
-                                      return DropdownMenuItem<int>(
-                                        value: days,
-                                        child: Text('$days'),
-                                      );
-                                    })
-                                    .toList(),
-                            onChanged: (int? newValue) {
-                                    if (newValue != null) {
-                                      setState(() {
-                                        _selectedGestationDays = newValue;
-                                      });
-                                    }
-                                  },
-                            validator: (value) {
-                              return null;
-                            },
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 16),
-                      // Sex Radio Buttons
-                      const Text(
-                        'Sex:',
-                        style: TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.bold,
+                          ],
                         ),
-                      ),
-                      EnumRadioGroup<Sex>(
-                        groupValue: _selectedSex,
-                        onChanged: (value) {
-                          setState(() {
-                            _selectedSex = value!;
-                          });
-                          _checkFormValidity();
-                        },
-                        values: Sex.values,
-                        labelBuilder: (m) {
-                          switch (m) {
-                            case Sex.male:
-                              return 'Boy';
-                            case Sex.female:
-                              return 'Girl';
-                          }
-                        },
-                      ),
-                      const SizedBox(height: 16),
-                      const Text(
-                        'Ages:',
-                        style: TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.bold,
+                        const SizedBox(height: 16),
+                        // Sex Radio Buttons
+                        const Text(
+                          'Sex:',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
-                      ),
-                      const SizedBox(height: 16),
-                      Row(
-                        children: [
-                          Expanded(
-                            child: TextFormField(
-                              controller: _startAge,
-                              keyboardType:
-                                  const TextInputType.numberWithOptions(),
-                              decoration: InputDecoration(
-                                labelText: 'Start (years)',
-                                border: const OutlineInputBorder(),
+                        EnumRadioGroup<Sex>(
+                          groupValue: _selectedSex,
+                          onChanged: (value) {
+                            setState(() {
+                              _selectedSex = value!;
+                            });
+                            _checkFormValidity();
+                          },
+                          values: Sex.values,
+                          labelBuilder: (m) {
+                            switch (m) {
+                              case Sex.male:
+                                return 'Boy';
+                              case Sex.female:
+                                return 'Girl';
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16),
+                        const Text(
+                          'Ages:',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: TextFormField(
+                                controller: _startAge,
+                                keyboardType:
+                                    const TextInputType.numberWithOptions(),
+                                decoration: InputDecoration(
+                                  labelText: 'Start (years)',
+                                  border: const OutlineInputBorder(),
+                                ),
+                                validator: (value) {
+                                  if (value != null &&
+                                      value.isNotEmpty &&
+                                      double.tryParse(value) == null) {
+                                    return 'Please enter a valid number';
+                                  }
+                                  return null; // Valid
+                                },
                               ),
-                              validator: (value) {
-                                if (value != null &&
-                                    value.isNotEmpty &&
-                                    double.tryParse(value) == null) {
-                                  return 'Please enter a valid number';
-                                }
-                                return null; // Valid
+                            ),
+                            const SizedBox(width: 16),
+                            // TODO MRB: put back once available in API
+                            // https://github.com/rcpch/rcpchgrowth-python/pull/99
+                            // DropdownButton<String>(
+                            //   value: _startAgeUnit,
+                            //   items: _ageUnits.map((String value) {
+                            //     return DropdownMenuItem<String>(
+                            //       value: value,
+                            //       child: Text(value),
+                            //     );
+                            //   }).toList(),
+                            //   onChanged: (value) {
+                            //     setState(() {
+                            //       _startAgeUnit = value!;
+                            //     });
+                            //   },
+                            // ),
+                          ],
+                        ),
+                        const SizedBox(height: 16),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: TextFormField(
+                                controller: _endAge,
+                                keyboardType:
+                                    const TextInputType.numberWithOptions(),
+                                decoration: InputDecoration(
+                                  labelText: 'End (years)',
+                                  border: const OutlineInputBorder(),
+                                ),
+                                validator: (value) {
+                                  if (value != null &&
+                                      value.isNotEmpty &&
+                                      double.tryParse(value) == null) {
+                                    return 'Please enter a valid number';
+                                  }
+                                  return null; // Valid
+                                },
+                              ),
+                            ),
+                            const SizedBox(width: 16),
+                            // TODO MRB: put back once available in API
+                            // https://github.com/rcpch/rcpchgrowth-python/pull/99
+                            // DropdownButton<String>(
+                            //   value: _endAgeUnit,
+                            //   items: _ageUnits.map((String value) {
+                            //     return DropdownMenuItem<String>(
+                            //       value: value,
+                            //       child: Text(value),
+                            //     );
+                            //   }).toList(),
+                            //   onChanged: (value) {
+                            //     setState(() {
+                            //       _endAgeUnit = value!;
+                            //     });
+                            //   },
+                            // ),
+                          ],
+                        ),
+                        const SizedBox(height: 16),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: TextFormField(
+                                controller: _interval,
+                                keyboardType:
+                                    const TextInputType.numberWithOptions(),
+                                decoration: InputDecoration(
+                                  labelText: 'Interval',
+                                  border: const OutlineInputBorder(),
+                                ),
+                                validator: (value) {
+                                  if (value != null &&
+                                      value.isNotEmpty &&
+                                      double.tryParse(value) == null) {
+                                    return 'Please enter a valid number';
+                                  }
+                                  return null; // Valid
+                                },
+                              ),
+                            ),
+                            const SizedBox(width: 16),
+                            DropdownButton<String>(
+                              value: _intervalUnit,
+                              items: _ageUnits.map((String value) {
+                                return DropdownMenuItem<String>(
+                                  value: value,
+                                  child: Text(value),
+                                );
+                              }).toList(),
+                              onChanged: (value) {
+                                setState(() {
+                                  _intervalUnit = value!;
+                                });
                               },
                             ),
-                          ),
-                          const SizedBox(width: 16),
-                          // TODO MRB: put back once available in API
-                          // https://github.com/rcpch/rcpchgrowth-python/pull/99
-                          // DropdownButton<String>(
-                          //   value: _startAgeUnit,
-                          //   items: _ageUnits.map((String value) {
-                          //     return DropdownMenuItem<String>(
-                          //       value: value,
-                          //       child: Text(value),
-                          //     );
-                          //   }).toList(),
-                          //   onChanged: (value) {
-                          //     setState(() {
-                          //       _startAgeUnit = value!;
-                          //     });
-                          //   },
-                          // ),
-                        ],
-                      ),
-                      const SizedBox(height: 16),
-                      Row(
-                        children: [
-                          Expanded(
-                            child: TextFormField(
-                              controller: _endAge,
-                              keyboardType:
-                                  const TextInputType.numberWithOptions(),
-                              decoration: InputDecoration(
-                                labelText: 'End (years)',
-                                border: const OutlineInputBorder(),
-                              ),
-                              validator: (value) {
-                                if (value != null &&
-                                    value.isNotEmpty &&
-                                    double.tryParse(value) == null) {
-                                  return 'Please enter a valid number';
-                                }
-                                return null; // Valid
-                              },
-                            ),
-                          ),
-                          const SizedBox(width: 16),
-                          // TODO MRB: put back once available in API
-                          // https://github.com/rcpch/rcpchgrowth-python/pull/99
-                          // DropdownButton<String>(
-                          //   value: _endAgeUnit,
-                          //   items: _ageUnits.map((String value) {
-                          //     return DropdownMenuItem<String>(
-                          //       value: value,
-                          //       child: Text(value),
-                          //     );
-                          //   }).toList(),
-                          //   onChanged: (value) {
-                          //     setState(() {
-                          //       _endAgeUnit = value!;
-                          //     });
-                          //   },
-                          // ),
-                        ],
-                      ),
-                      const SizedBox(height: 16),
-                      Row(
-                        children: [
-                          Expanded(
-                            child: TextFormField(
-                              controller: _interval,
-                              keyboardType:
-                                  const TextInputType.numberWithOptions(),
-                              decoration: InputDecoration(
-                                labelText: 'Interval',
-                                border: const OutlineInputBorder(),
-                              ),
-                              validator: (value) {
-                                if (value != null &&
-                                    value.isNotEmpty &&
-                                    double.tryParse(value) == null) {
-                                  return 'Please enter a valid number';
-                                }
-                                return null; // Valid
-                              },
-                            ),
-                          ),
-                          const SizedBox(width: 16),
-                          DropdownButton<String>(
-                            value: _intervalUnit,
-                            items: _ageUnits.map((String value) {
-                              return DropdownMenuItem<String>(
-                                value: value,
-                                child: Text(value),
-                              );
-                            }).toList(),
-                            onChanged: (value) {
-                              setState(() {
-                                _intervalUnit = value!;
-                              });
-                            },
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 16),
-                      EnumRadioGroup<MeasurementMethod>(
-                        groupValue: _measurementMethod,
-                        onChanged: (value) {
-                          setState(() {
-                            _measurementMethod = value!;
-                          });
-                          _checkFormValidity();
-                        },
-                        values: MeasurementMethod.values,
-                        labelBuilder: _measurementMethodToString
-                      ),
-                      const SizedBox(height: 16),
+                          ],
+                        ),
+                        const SizedBox(height: 16),
+                        EnumRadioGroup<MeasurementMethod>(
+                          groupValue: _measurementMethod,
+                          onChanged: (value) {
+                            setState(() {
+                              _measurementMethod = value!;
+                            });
+                            _checkFormValidity();
+                          },
+                          values: MeasurementMethod.values,
+                          labelBuilder: _measurementMethodToString,
+                        ),
+                        const SizedBox(height: 16),
 
-                      // Submit Button
-                      ElevatedButton(
-                        onPressed: _canSubmit && !_loading ? _submitForm : null,
-                        style: ButtonStyle(
-                          backgroundColor: WidgetStateProperty.resolveWith<Color?>((
-                            Set<WidgetState> states,
-                          ) {
-                            if (states.contains(WidgetState.disabled)) {
-                              return Colors
-                                  .grey; // Optional: custom disabled color
-                            }
-                            if (states.contains(WidgetState.pressed)) {
-                              return secondaryColour;
-                            }
-                            return primaryColour; // Use the component's default.
-                          }),
-                          shape: WidgetStateProperty.all<RoundedRectangleBorder>(
-                            RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(0),
-                            ),
+                        // Submit Button
+                        ElevatedButton(
+                          onPressed: _canSubmit && !_loading
+                              ? _submitForm
+                              : null,
+                          style: ButtonStyle(
+                            backgroundColor:
+                                WidgetStateProperty.resolveWith<Color?>((
+                                  Set<WidgetState> states,
+                                ) {
+                                  if (states.contains(WidgetState.disabled)) {
+                                    return Colors
+                                        .grey; // Optional: custom disabled color
+                                  }
+                                  if (states.contains(WidgetState.pressed)) {
+                                    return secondaryColour;
+                                  }
+                                  return primaryColour; // Use the component's default.
+                                }),
+                            shape:
+                                WidgetStateProperty.all<RoundedRectangleBorder>(
+                                  RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(0),
+                                  ),
+                                ),
+                          ),
+                          child: Text(
+                            _loading ? 'Loading...' : 'Submit',
+                            style: TextStyle(color: Colors.white),
                           ),
                         ),
-                        child: Text(
-                          _loading ? 'Loading...' : 'Submit',
-                          style: TextStyle(color: Colors.white),
-                        ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
-              ),
               ),
             ],
           ),

--- a/lib/widgets/generator.dart
+++ b/lib/widgets/generator.dart
@@ -1,0 +1,350 @@
+import 'package:flutter/material.dart';
+// RCPCH imports
+import 'package:digital_growth_charts_app/themes/colours.dart';
+import 'package:provider/provider.dart';
+import '../definitions/enums.dart';
+import '../widgets/enum_radio_group.dart';
+import '../classes/app_state.dart';
+
+class GeneratorFormState extends State<GeneratorForm> {
+  // A GlobalKey to uniquely identify the Form widget
+  final _formKey = GlobalKey<FormState>();
+  bool _canSubmit = false;
+
+  final List<String> _ageUnits = ['Years', 'Months', 'Weeks', 'Days'];
+
+  int _selectedGestationWeeks = 40;
+  int _selectedGestationDays = 0;
+  Sex _selectedSex = Sex.male;
+
+  final TextEditingController _startAge = TextEditingController();
+  String _startAgeUnit = 'Years';
+
+  final TextEditingController _endAge = TextEditingController();
+  String _endAgeUnit = 'Years';
+
+  final TextEditingController _interval = TextEditingController();
+  String _intervalUnit = 'Years';
+
+  bool _loading = false;
+
+  void _checkFormValidity() {
+    // Validate the form and update the _canSubmit state
+    // The null check for currentState is important if the form might not be built yet.
+    if (_formKey.currentState != null && _formKey.currentState!.validate()) {
+      setState(() {
+        _canSubmit = !_canSubmit;
+      });
+    }
+  }
+
+  void _submitForm() {
+    if (_formKey.currentState?.validate() ?? false) {
+      setState(() {
+        _loading = true;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var appState = context.watch<AppState>();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Generate data')),
+      body: Center(
+        child: Column(
+          children: [
+            Form(
+              // Wrap form content in a Form widget
+              key: _formKey, // Assign the GlobalKey
+              autovalidateMode: AutovalidateMode.onUserInteraction,
+              onChanged: () {
+                setState(() {
+                  _canSubmit = _formKey.currentState?.validate() ?? false;
+                });
+                _checkFormValidity();
+              },
+              child: SingleChildScrollView(
+                // Add SingleChildScrollView to prevent overflow on smaller screens
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text(
+                          'Gestation Weeks:',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        DropdownButtonFormField<int>(
+                          decoration: const InputDecoration(
+                            border: OutlineInputBorder(),
+                          ),
+                          initialValue: _selectedGestationWeeks,
+                          items:
+                              List.generate(
+                                    19,
+                                    (index) => index + 24,
+                                  ) // Weeks 24 to 42
+                                  .map((int weeks) {
+                                    return DropdownMenuItem<int>(
+                                      value: weeks,
+                                      child: Text('$weeks'),
+                                    );
+                                  })
+                                  .toList(),
+                          onChanged: appState.organizedGrowthData.isNotEmpty
+                              ? null
+                              : (int? newValue) {
+                                  if (newValue != null) {
+                                    setState(() {
+                                      _selectedGestationWeeks = newValue;
+                                    });
+                                  }
+                                },
+                          validator: (value) {
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: 16),
+                        const Text(
+                          'Gestation Days:',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        DropdownButtonFormField<int>(
+                          decoration: const InputDecoration(
+                            border: OutlineInputBorder(),
+                          ),
+                          initialValue: _selectedGestationDays,
+                          items:
+                              List.generate(7, (index) => index) // Days 0 to 6
+                                  .map((int days) {
+                                    return DropdownMenuItem<int>(
+                                      value: days,
+                                      child: Text('$days'),
+                                    );
+                                  })
+                                  .toList(),
+                          onChanged: appState.organizedGrowthData.isNotEmpty
+                              ? null
+                              : (int? newValue) {
+                                  if (newValue != null) {
+                                    setState(() {
+                                      _selectedGestationDays = newValue;
+                                    });
+                                  }
+                                },
+                          validator: (value) {
+                            return null;
+                          },
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 16),
+                    // Sex Radio Buttons
+                    const Text(
+                      'Sex:',
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    EnumRadioGroup<Sex>(
+                      groupValue: _selectedSex,
+                      onChanged: (value) {
+                        setState(() {
+                          _selectedSex = value!;
+                        });
+                        _checkFormValidity();
+                      },
+                      enabled: appState.organizedGrowthData.isEmpty,
+                      values: Sex.values,
+                      labelBuilder: (m) {
+                        switch (m) {
+                          case Sex.male:
+                            return 'Boy';
+                          case Sex.female:
+                            return 'Girl';
+                        }
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                    const Text(
+                      'Ages:',
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: TextFormField(
+                            controller: _startAge,
+                            keyboardType:
+                                const TextInputType.numberWithOptions(),
+                            decoration: InputDecoration(
+                              labelText: 'Start (years)',
+                              border: const OutlineInputBorder(),
+                            ),
+                            validator: (value) {
+                              if (value != null &&
+                                  value.isNotEmpty &&
+                                  double.tryParse(value) == null) {
+                                return 'Please enter a valid number';
+                              }
+                              return null; // Valid
+                            },
+                          ),
+                        ),
+                        const SizedBox(width: 16),
+                        // TODO MRB: put back once available in API
+                        // https://github.com/rcpch/rcpchgrowth-python/pull/99
+                        // DropdownButton<String>(
+                        //   value: _startAgeUnit,
+                        //   items: _ageUnits.map((String value) {
+                        //     return DropdownMenuItem<String>(
+                        //       value: value,
+                        //       child: Text(value),
+                        //     );
+                        //   }).toList(),
+                        //   onChanged: (value) {
+                        //     setState(() {
+                        //       _startAgeUnit = value!;
+                        //     });
+                        //   },
+                        // ),
+                      ],
+                    ),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: TextFormField(
+                            controller: _endAge,
+                            keyboardType:
+                                const TextInputType.numberWithOptions(),
+                            decoration: InputDecoration(
+                              labelText: 'End (years)',
+                              border: const OutlineInputBorder(),
+                            ),
+                            validator: (value) {
+                              if (value != null &&
+                                  value.isNotEmpty &&
+                                  double.tryParse(value) == null) {
+                                return 'Please enter a valid number';
+                              }
+                              return null; // Valid
+                            },
+                          ),
+                        ),
+                        const SizedBox(width: 16),
+                        // TODO MRB: put back once available in API
+                        // https://github.com/rcpch/rcpchgrowth-python/pull/99
+                        // DropdownButton<String>(
+                        //   value: _endAgeUnit,
+                        //   items: _ageUnits.map((String value) {
+                        //     return DropdownMenuItem<String>(
+                        //       value: value,
+                        //       child: Text(value),
+                        //     );
+                        //   }).toList(),
+                        //   onChanged: (value) {
+                        //     setState(() {
+                        //       _endAgeUnit = value!;
+                        //     });
+                        //   },
+                        // ),
+                      ],
+                    ),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: TextFormField(
+                            controller: _interval,
+                            keyboardType:
+                                const TextInputType.numberWithOptions(),
+                            decoration: InputDecoration(
+                              labelText: 'Interval',
+                              border: const OutlineInputBorder(),
+                            ),
+                            validator: (value) {
+                              if (value != null &&
+                                  value.isNotEmpty &&
+                                  double.tryParse(value) == null) {
+                                return 'Please enter a valid number';
+                              }
+                              return null; // Valid
+                            },
+                          ),
+                        ),
+                        const SizedBox(width: 16),
+                        DropdownButton<String>(
+                          value: _intervalUnit,
+                          items: _ageUnits.map((String value) {
+                            return DropdownMenuItem<String>(
+                              value: value,
+                              child: Text(value),
+                            );
+                          }).toList(),
+                          onChanged: (value) {
+                            setState(() {
+                              _intervalUnit = value!;
+                            });
+                          },
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 16),
+
+                    // Submit Button
+                    ElevatedButton(
+                      onPressed: _canSubmit && !_loading ? _submitForm : null,
+                      style: ButtonStyle(
+                        backgroundColor: WidgetStateProperty.resolveWith<Color?>((
+                          Set<WidgetState> states,
+                        ) {
+                          if (states.contains(WidgetState.disabled)) {
+                            return Colors
+                                .grey; // Optional: custom disabled color
+                          }
+                          if (states.contains(WidgetState.pressed)) {
+                            return secondaryColour;
+                          }
+                          return primaryColour; // Use the component's default.
+                        }),
+                        shape: WidgetStateProperty.all<RoundedRectangleBorder>(
+                          RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(0),
+                          ),
+                        ),
+                      ),
+                      child: Text(
+                        _loading ? 'Loading...' : 'Submit',
+                        style: TextStyle(color: Colors.white),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class GeneratorForm extends StatefulWidget {
+  const GeneratorForm({super.key});
+
+  @override
+  GeneratorFormState createState() => GeneratorFormState();
+}

--- a/lib/widgets/generator.dart
+++ b/lib/widgets/generator.dart
@@ -80,308 +80,310 @@ class GeneratorFormState extends State<GeneratorForm> {
 
     return Scaffold(
       appBar: AppBar(title: const Text('Generate data')),
-      body: Center(
-        child: Column(
-          children: [
-            Expanded(
-              child: Form(
-              // Wrap form content in a Form widget
-              key: _formKey, // Assign the GlobalKey
-              autovalidateMode: AutovalidateMode.onUserInteraction,
-              onChanged: () {
-                setState(() {
-                  _canSubmit = _formKey.currentState?.validate() ?? false;
-                });
-                _checkFormValidity();
-              },
-              child: SingleChildScrollView(
-                // Add SingleChildScrollView to prevent overflow on smaller screens
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: <Widget>[
-                    Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const Text(
-                          'Gestation Weeks:',
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.bold,
+      body: SafeArea(
+        child: Center(
+          child: Column(
+            children: [
+              Expanded(
+                child: Form(
+                // Wrap form content in a Form widget
+                key: _formKey, // Assign the GlobalKey
+                autovalidateMode: AutovalidateMode.onUserInteraction,
+                onChanged: () {
+                  setState(() {
+                    _canSubmit = _formKey.currentState?.validate() ?? false;
+                  });
+                  _checkFormValidity();
+                },
+                child: SingleChildScrollView(
+                  // Add SingleChildScrollView to prevent overflow on smaller screens
+                  padding: const EdgeInsets.all(16.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: <Widget>[
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Text(
+                            'Gestation Weeks:',
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.bold,
+                            ),
                           ),
-                        ),
-                        DropdownButtonFormField<int>(
-                          decoration: const InputDecoration(
-                            border: OutlineInputBorder(),
+                          DropdownButtonFormField<int>(
+                            decoration: const InputDecoration(
+                              border: OutlineInputBorder(),
+                            ),
+                            initialValue: _selectedGestationWeeks,
+                            items:
+                                List.generate(
+                                      19,
+                                      (index) => index + 24,
+                                    ) // Weeks 24 to 42
+                                    .map((int weeks) {
+                                      return DropdownMenuItem<int>(
+                                        value: weeks,
+                                        child: Text('$weeks'),
+                                      );
+                                    })
+                                    .toList(),
+                            onChanged: appState.organizedGrowthData.isNotEmpty
+                                ? null
+                                : (int? newValue) {
+                                    if (newValue != null) {
+                                      setState(() {
+                                        _selectedGestationWeeks = newValue;
+                                      });
+                                    }
+                                  },
+                            validator: (value) {
+                              return null;
+                            },
                           ),
-                          initialValue: _selectedGestationWeeks,
-                          items:
-                              List.generate(
-                                    19,
-                                    (index) => index + 24,
-                                  ) // Weeks 24 to 42
-                                  .map((int weeks) {
-                                    return DropdownMenuItem<int>(
-                                      value: weeks,
-                                      child: Text('$weeks'),
-                                    );
-                                  })
-                                  .toList(),
-                          onChanged: appState.organizedGrowthData.isNotEmpty
-                              ? null
-                              : (int? newValue) {
-                                  if (newValue != null) {
-                                    setState(() {
-                                      _selectedGestationWeeks = newValue;
-                                    });
-                                  }
-                                },
-                          validator: (value) {
-                            return null;
-                          },
-                        ),
-                        const SizedBox(height: 16),
-                        const Text(
-                          'Gestation Days:',
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.bold,
+                          const SizedBox(height: 16),
+                          const Text(
+                            'Gestation Days:',
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.bold,
+                            ),
                           ),
-                        ),
-                        DropdownButtonFormField<int>(
-                          decoration: const InputDecoration(
-                            border: OutlineInputBorder(),
+                          DropdownButtonFormField<int>(
+                            decoration: const InputDecoration(
+                              border: OutlineInputBorder(),
+                            ),
+                            initialValue: _selectedGestationDays,
+                            items:
+                                List.generate(7, (index) => index) // Days 0 to 6
+                                    .map((int days) {
+                                      return DropdownMenuItem<int>(
+                                        value: days,
+                                        child: Text('$days'),
+                                      );
+                                    })
+                                    .toList(),
+                            onChanged: appState.organizedGrowthData.isNotEmpty
+                                ? null
+                                : (int? newValue) {
+                                    if (newValue != null) {
+                                      setState(() {
+                                        _selectedGestationDays = newValue;
+                                      });
+                                    }
+                                  },
+                            validator: (value) {
+                              return null;
+                            },
                           ),
-                          initialValue: _selectedGestationDays,
-                          items:
-                              List.generate(7, (index) => index) // Days 0 to 6
-                                  .map((int days) {
-                                    return DropdownMenuItem<int>(
-                                      value: days,
-                                      child: Text('$days'),
-                                    );
-                                  })
-                                  .toList(),
-                          onChanged: appState.organizedGrowthData.isNotEmpty
-                              ? null
-                              : (int? newValue) {
-                                  if (newValue != null) {
-                                    setState(() {
-                                      _selectedGestationDays = newValue;
-                                    });
-                                  }
-                                },
-                          validator: (value) {
-                            return null;
-                          },
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 16),
-                    // Sex Radio Buttons
-                    const Text(
-                      'Sex:',
-                      style: TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.bold,
+                        ],
                       ),
-                    ),
-                    EnumRadioGroup<Sex>(
-                      groupValue: _selectedSex,
-                      onChanged: (value) {
-                        setState(() {
-                          _selectedSex = value!;
-                        });
-                        _checkFormValidity();
-                      },
-                      enabled: appState.organizedGrowthData.isEmpty,
-                      values: Sex.values,
-                      labelBuilder: (m) {
-                        switch (m) {
-                          case Sex.male:
-                            return 'Boy';
-                          case Sex.female:
-                            return 'Girl';
-                        }
-                      },
-                    ),
-                    const SizedBox(height: 16),
-                    const Text(
-                      'Ages:',
-                      style: TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.bold,
+                      const SizedBox(height: 16),
+                      // Sex Radio Buttons
+                      const Text(
+                        'Sex:',
+                        style: TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
-                    ),
-                    const SizedBox(height: 16),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: TextFormField(
-                            controller: _startAge,
-                            keyboardType:
-                                const TextInputType.numberWithOptions(),
-                            decoration: InputDecoration(
-                              labelText: 'Start (years)',
-                              border: const OutlineInputBorder(),
+                      EnumRadioGroup<Sex>(
+                        groupValue: _selectedSex,
+                        onChanged: (value) {
+                          setState(() {
+                            _selectedSex = value!;
+                          });
+                          _checkFormValidity();
+                        },
+                        enabled: appState.organizedGrowthData.isEmpty,
+                        values: Sex.values,
+                        labelBuilder: (m) {
+                          switch (m) {
+                            case Sex.male:
+                              return 'Boy';
+                            case Sex.female:
+                              return 'Girl';
+                          }
+                        },
+                      ),
+                      const SizedBox(height: 16),
+                      const Text(
+                        'Ages:',
+                        style: TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: TextFormField(
+                              controller: _startAge,
+                              keyboardType:
+                                  const TextInputType.numberWithOptions(),
+                              decoration: InputDecoration(
+                                labelText: 'Start (years)',
+                                border: const OutlineInputBorder(),
+                              ),
+                              validator: (value) {
+                                if (value != null &&
+                                    value.isNotEmpty &&
+                                    double.tryParse(value) == null) {
+                                  return 'Please enter a valid number';
+                                }
+                                return null; // Valid
+                              },
                             ),
-                            validator: (value) {
-                              if (value != null &&
-                                  value.isNotEmpty &&
-                                  double.tryParse(value) == null) {
-                                return 'Please enter a valid number';
-                              }
-                              return null; // Valid
+                          ),
+                          const SizedBox(width: 16),
+                          // TODO MRB: put back once available in API
+                          // https://github.com/rcpch/rcpchgrowth-python/pull/99
+                          // DropdownButton<String>(
+                          //   value: _startAgeUnit,
+                          //   items: _ageUnits.map((String value) {
+                          //     return DropdownMenuItem<String>(
+                          //       value: value,
+                          //       child: Text(value),
+                          //     );
+                          //   }).toList(),
+                          //   onChanged: (value) {
+                          //     setState(() {
+                          //       _startAgeUnit = value!;
+                          //     });
+                          //   },
+                          // ),
+                        ],
+                      ),
+                      const SizedBox(height: 16),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: TextFormField(
+                              controller: _endAge,
+                              keyboardType:
+                                  const TextInputType.numberWithOptions(),
+                              decoration: InputDecoration(
+                                labelText: 'End (years)',
+                                border: const OutlineInputBorder(),
+                              ),
+                              validator: (value) {
+                                if (value != null &&
+                                    value.isNotEmpty &&
+                                    double.tryParse(value) == null) {
+                                  return 'Please enter a valid number';
+                                }
+                                return null; // Valid
+                              },
+                            ),
+                          ),
+                          const SizedBox(width: 16),
+                          // TODO MRB: put back once available in API
+                          // https://github.com/rcpch/rcpchgrowth-python/pull/99
+                          // DropdownButton<String>(
+                          //   value: _endAgeUnit,
+                          //   items: _ageUnits.map((String value) {
+                          //     return DropdownMenuItem<String>(
+                          //       value: value,
+                          //       child: Text(value),
+                          //     );
+                          //   }).toList(),
+                          //   onChanged: (value) {
+                          //     setState(() {
+                          //       _endAgeUnit = value!;
+                          //     });
+                          //   },
+                          // ),
+                        ],
+                      ),
+                      const SizedBox(height: 16),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: TextFormField(
+                              controller: _interval,
+                              keyboardType:
+                                  const TextInputType.numberWithOptions(),
+                              decoration: InputDecoration(
+                                labelText: 'Interval',
+                                border: const OutlineInputBorder(),
+                              ),
+                              validator: (value) {
+                                if (value != null &&
+                                    value.isNotEmpty &&
+                                    double.tryParse(value) == null) {
+                                  return 'Please enter a valid number';
+                                }
+                                return null; // Valid
+                              },
+                            ),
+                          ),
+                          const SizedBox(width: 16),
+                          DropdownButton<String>(
+                            value: _intervalUnit,
+                            items: _ageUnits.map((String value) {
+                              return DropdownMenuItem<String>(
+                                value: value,
+                                child: Text(value),
+                              );
+                            }).toList(),
+                            onChanged: (value) {
+                              setState(() {
+                                _intervalUnit = value!;
+                              });
                             },
                           ),
-                        ),
-                        const SizedBox(width: 16),
-                        // TODO MRB: put back once available in API
-                        // https://github.com/rcpch/rcpchgrowth-python/pull/99
-                        // DropdownButton<String>(
-                        //   value: _startAgeUnit,
-                        //   items: _ageUnits.map((String value) {
-                        //     return DropdownMenuItem<String>(
-                        //       value: value,
-                        //       child: Text(value),
-                        //     );
-                        //   }).toList(),
-                        //   onChanged: (value) {
-                        //     setState(() {
-                        //       _startAgeUnit = value!;
-                        //     });
-                        //   },
-                        // ),
-                      ],
-                    ),
-                    const SizedBox(height: 16),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: TextFormField(
-                            controller: _endAge,
-                            keyboardType:
-                                const TextInputType.numberWithOptions(),
-                            decoration: InputDecoration(
-                              labelText: 'End (years)',
-                              border: const OutlineInputBorder(),
-                            ),
-                            validator: (value) {
-                              if (value != null &&
-                                  value.isNotEmpty &&
-                                  double.tryParse(value) == null) {
-                                return 'Please enter a valid number';
-                              }
-                              return null; // Valid
-                            },
-                          ),
-                        ),
-                        const SizedBox(width: 16),
-                        // TODO MRB: put back once available in API
-                        // https://github.com/rcpch/rcpchgrowth-python/pull/99
-                        // DropdownButton<String>(
-                        //   value: _endAgeUnit,
-                        //   items: _ageUnits.map((String value) {
-                        //     return DropdownMenuItem<String>(
-                        //       value: value,
-                        //       child: Text(value),
-                        //     );
-                        //   }).toList(),
-                        //   onChanged: (value) {
-                        //     setState(() {
-                        //       _endAgeUnit = value!;
-                        //     });
-                        //   },
-                        // ),
-                      ],
-                    ),
-                    const SizedBox(height: 16),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: TextFormField(
-                            controller: _interval,
-                            keyboardType:
-                                const TextInputType.numberWithOptions(),
-                            decoration: InputDecoration(
-                              labelText: 'Interval',
-                              border: const OutlineInputBorder(),
-                            ),
-                            validator: (value) {
-                              if (value != null &&
-                                  value.isNotEmpty &&
-                                  double.tryParse(value) == null) {
-                                return 'Please enter a valid number';
-                              }
-                              return null; // Valid
-                            },
-                          ),
-                        ),
-                        const SizedBox(width: 16),
-                        DropdownButton<String>(
-                          value: _intervalUnit,
-                          items: _ageUnits.map((String value) {
-                            return DropdownMenuItem<String>(
-                              value: value,
-                              child: Text(value),
-                            );
-                          }).toList(),
-                          onChanged: (value) {
-                            setState(() {
-                              _intervalUnit = value!;
-                            });
-                          },
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 16),
-                    EnumRadioGroup<MeasurementMethod>(
-                      groupValue: _measurementMethod,
-                      onChanged: (value) {
-                        setState(() {
-                          _measurementMethod = value!;
-                        });
-                        _checkFormValidity();
-                      },
-                      enabled: appState.organizedGrowthData.isEmpty,
-                      values: MeasurementMethod.values,
-                      labelBuilder: _measurementMethodToString
-                    ),
-                    const SizedBox(height: 16),
+                        ],
+                      ),
+                      const SizedBox(height: 16),
+                      EnumRadioGroup<MeasurementMethod>(
+                        groupValue: _measurementMethod,
+                        onChanged: (value) {
+                          setState(() {
+                            _measurementMethod = value!;
+                          });
+                          _checkFormValidity();
+                        },
+                        enabled: appState.organizedGrowthData.isEmpty,
+                        values: MeasurementMethod.values,
+                        labelBuilder: _measurementMethodToString
+                      ),
+                      const SizedBox(height: 16),
 
-                    // Submit Button
-                    ElevatedButton(
-                      onPressed: _canSubmit && !_loading ? _submitForm : null,
-                      style: ButtonStyle(
-                        backgroundColor: WidgetStateProperty.resolveWith<Color?>((
-                          Set<WidgetState> states,
-                        ) {
-                          if (states.contains(WidgetState.disabled)) {
-                            return Colors
-                                .grey; // Optional: custom disabled color
-                          }
-                          if (states.contains(WidgetState.pressed)) {
-                            return secondaryColour;
-                          }
-                          return primaryColour; // Use the component's default.
-                        }),
-                        shape: WidgetStateProperty.all<RoundedRectangleBorder>(
-                          RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(0),
+                      // Submit Button
+                      ElevatedButton(
+                        onPressed: _canSubmit && !_loading ? _submitForm : null,
+                        style: ButtonStyle(
+                          backgroundColor: WidgetStateProperty.resolveWith<Color?>((
+                            Set<WidgetState> states,
+                          ) {
+                            if (states.contains(WidgetState.disabled)) {
+                              return Colors
+                                  .grey; // Optional: custom disabled color
+                            }
+                            if (states.contains(WidgetState.pressed)) {
+                              return secondaryColour;
+                            }
+                            return primaryColour; // Use the component's default.
+                          }),
+                          shape: WidgetStateProperty.all<RoundedRectangleBorder>(
+                            RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(0),
+                            ),
                           ),
                         ),
+                        child: Text(
+                          _loading ? 'Loading...' : 'Submit',
+                          style: TextStyle(color: Colors.white),
+                        ),
                       ),
-                      child: Text(
-                        _loading ? 'Loading...' : 'Submit',
-                        style: TextStyle(color: Colors.white),
-                      ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
-            ),
-            ),
-          ],
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/generator.dart
+++ b/lib/widgets/generator.dart
@@ -26,6 +26,8 @@ class GeneratorFormState extends State<GeneratorForm> {
   final TextEditingController _interval = TextEditingController(text: '1');
   String _intervalUnit = 'Years';
 
+  MeasurementMethod _measurementMethod = MeasurementMethod.height;
+
   bool _loading = false;
 
   void _checkFormValidity() {
@@ -38,11 +40,37 @@ class GeneratorFormState extends State<GeneratorForm> {
     }
   }
 
-  void _submitForm() {
+  void _submitForm() async {
     if (_formKey.currentState?.validate() ?? false) {
       setState(() {
         _loading = true;
       });
+    }
+
+    var appState = Provider.of<AppState>(context, listen: false);
+
+    appState.generateFictionalData(
+      gestationWeeks: _selectedGestationWeeks,
+      gestationDays: _selectedGestationDays,
+      sex: _selectedSex,
+      startChronologicalAge: double.parse(_startAge.text),
+      endAge: double.parse(_endAge.text),
+      measurementIntervalNumber: double.parse(_interval.text),
+      measurementIntervalType: _intervalUnit.toLowerCase(),
+      measurementMethod: _measurementMethod,
+    );
+  }
+
+  String _measurementMethodToString(MeasurementMethod method) {
+    switch (method) {
+      case MeasurementMethod.height:
+        return 'Height';
+      case MeasurementMethod.weight:
+        return 'Weight';
+      case MeasurementMethod.ofc:
+        return 'Head Cm.';
+      case MeasurementMethod.bmi:
+        return 'BMI';
     }
   }
 
@@ -55,7 +83,8 @@ class GeneratorFormState extends State<GeneratorForm> {
       body: Center(
         child: Column(
           children: [
-            Form(
+            Expanded(
+              child: Form(
               // Wrap form content in a Form widget
               key: _formKey, // Assign the GlobalKey
               autovalidateMode: AutovalidateMode.onUserInteraction,
@@ -306,6 +335,19 @@ class GeneratorFormState extends State<GeneratorForm> {
                       ],
                     ),
                     const SizedBox(height: 16),
+                    EnumRadioGroup<MeasurementMethod>(
+                      groupValue: _measurementMethod,
+                      onChanged: (value) {
+                        setState(() {
+                          _measurementMethod = value!;
+                        });
+                        _checkFormValidity();
+                      },
+                      enabled: appState.organizedGrowthData.isEmpty,
+                      values: MeasurementMethod.values,
+                      labelBuilder: _measurementMethodToString
+                    ),
+                    const SizedBox(height: 16),
 
                     // Submit Button
                     ElevatedButton(
@@ -337,6 +379,7 @@ class GeneratorFormState extends State<GeneratorForm> {
                   ],
                 ),
               ),
+            ),
             ),
           ],
         ),

--- a/lib/widgets/generator.dart
+++ b/lib/widgets/generator.dart
@@ -19,10 +19,14 @@ class GeneratorFormState extends State<GeneratorForm> {
   Sex _selectedSex = Sex.male;
 
   final TextEditingController _startAge = TextEditingController(text: '0');
-  String _startAgeUnit = 'Years';
+  // TODO MRB: put back once available in API
+  // https://github.com/rcpch/rcpchgrowth-python/pull/99
+  // String _startAgeUnit = 'Years';
 
   final TextEditingController _endAge = TextEditingController(text: '20');
-  String _endAgeUnit = 'Years';
+  // TODO MRB: put back once available in API
+  // https://github.com/rcpch/rcpchgrowth-python/pull/99
+  // String _endAgeUnit = 'Years';
 
   final TextEditingController _interval = TextEditingController(text: '1');
   String _intervalUnit = 'Years';
@@ -33,12 +37,10 @@ class GeneratorFormState extends State<GeneratorForm> {
 
   void _checkFormValidity() {
     // Validate the form and update the _canSubmit state
-    // The null check for currentState is important if the form might not be built yet.
-    if (_formKey.currentState != null && _formKey.currentState!.validate()) {
-      setState(() {
-        _canSubmit = !_canSubmit;
-      });
-    }
+    setState(() {
+      _canSubmit =
+          _formKey.currentState != null && _formKey.currentState!.validate();
+    });
   }
 
   void _submitForm() async {

--- a/lib/widgets/input.dart
+++ b/lib/widgets/input.dart
@@ -341,6 +341,22 @@ class InputFormState extends State<InputForm> {
   Widget build(BuildContext context) {
     var appState = context.watch<AppState>();
 
+    // Sync demographics from AppState in case they changed after initState
+    // (e.g. after generating fictional test data from another route).
+    if (appState.dob != null && appState.dob != _selectedDob) {
+      _selectedDob = appState.dob;
+      _dobController.text = DateFormat('yyyy-MM-dd').format(appState.dob!);
+    }
+    if (appState.sex != null && appState.sex != _selectedSex) {
+      _selectedSex = appState.sex!;
+    }
+    if (appState.gestationWeeks != null &&
+        appState.gestationWeeks != _selectedGestationWeeks) {
+      _selectedGestationWeeks = appState.gestationWeeks!;
+      _selectedGestationDays = appState.gestationDays!;
+      _showGestationFields = true;
+    }
+
     return Form(
       // Wrap form content in a Form widget
       key: _formKey, // Assign the GlobalKey

--- a/lib/widgets/settings.dart
+++ b/lib/widgets/settings.dart
@@ -1,4 +1,6 @@
 import 'package:digital_growth_charts_app/definitions/enums.dart';
+import 'package:digital_growth_charts_app/themes/colours.dart';
+import 'package:digital_growth_charts_app/widgets/generator.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../classes/app_state.dart';
@@ -55,6 +57,30 @@ class Settings extends StatelessWidget {
       appBar: AppBar(title: const Text('RCPCH Growth Charts')),
       body: Column(
         children: [
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => GeneratorForm()),
+              );
+            },
+            style: ButtonStyle(
+              backgroundColor: WidgetStateProperty.resolveWith<Color?>((
+                Set<WidgetState> states,
+              ) {
+                return primaryColour; // Use the component's default.
+              }),
+              shape: WidgetStateProperty.all<RoundedRectangleBorder>(
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(0)),
+              ),
+            ),
+            child: Text(
+              'Generate Test Data',
+              style: TextStyle(color: Colors.white),
+            ),
+          ),
+          const SizedBox(height: 16),
           const Text(
             'Test new features 🚀',
             style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),


### PR DESCRIPTION
Part of #26 

Add a page that uses the fictional child API endpoints to generate data.

[Screencast_20260820_120406.webm](https://github.com/user-attachments/assets/9025ec06-6cbe-41f7-a878-1b3651e6214d)



This makes testing a little easier but is still not quite what we need to close the original issue. In particular:

- It's often better to import a scenario (e.g. born preterm, pubertal delay) rather than generate data
  - @pacharanero and I have also discussed improving the scenarios available on the demo based on our Storybook
- The scenarios should include multiple measurements (including derived BMI)